### PR TITLE
Update Composer dependencies (2018-09-24)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1441,28 +1441,28 @@
         },
         {
             "name": "wp-cli/core-command",
-            "version": "v2.0.0",
+            "version": "v2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/core-command.git",
-                "reference": "b2d362a38c377e20f009e8f782daf5ba07e4c379"
+                "reference": "727a2f90ee72ed7654b39453c92ff74130696879"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/core-command/zipball/b2d362a38c377e20f009e8f782daf5ba07e4c379",
-                "reference": "b2d362a38c377e20f009e8f782daf5ba07e4c379",
+                "url": "https://api.github.com/repos/wp-cli/core-command/zipball/727a2f90ee72ed7654b39453c92ff74130696879",
+                "reference": "727a2f90ee72ed7654b39453c92ff74130696879",
                 "shasum": ""
             },
             "require": {
                 "composer/semver": "^1.4",
-                "wp-cli/wp-cli": "^2"
+                "wp-cli/wp-cli": "dev-master"
             },
             "require-dev": {
                 "wp-cli/checksum-command": "^1 || ^2",
                 "wp-cli/db-command": "^1.3 || ^2",
                 "wp-cli/entity-command": "^1.3 || ^2",
                 "wp-cli/extension-command": "^1.2 || ^2",
-                "wp-cli/wp-cli-tests": "^2"
+                "wp-cli/wp-cli-tests": "^2.0.7"
             },
             "type": "wp-cli-package",
             "extra": {
@@ -1504,7 +1504,7 @@
             ],
             "description": "Downloads, installs, updates, and manages a WordPress installation.",
             "homepage": "https://github.com/wp-cli/core-command",
-            "time": "2018-08-05T12:31:21+00:00"
+            "time": "2018-09-21T16:59:50+00:00"
         },
         {
             "name": "wp-cli/cron-command",
@@ -1907,23 +1907,23 @@
         },
         {
             "name": "wp-cli/eval-command",
-            "version": "v2.0.0",
+            "version": "v2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/eval-command.git",
-                "reference": "4a53bbf192ab7baa1fe4aa442c02801aa17ed6f4"
+                "reference": "26d3e6f609dc60d62b55d65552a2d984eb722713"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/eval-command/zipball/4a53bbf192ab7baa1fe4aa442c02801aa17ed6f4",
-                "reference": "4a53bbf192ab7baa1fe4aa442c02801aa17ed6f4",
+                "url": "https://api.github.com/repos/wp-cli/eval-command/zipball/26d3e6f609dc60d62b55d65552a2d984eb722713",
+                "reference": "26d3e6f609dc60d62b55d65552a2d984eb722713",
                 "shasum": ""
             },
             "require": {
                 "wp-cli/wp-cli": "^2"
             },
             "require-dev": {
-                "wp-cli/wp-cli-tests": "^2"
+                "wp-cli/wp-cli-tests": "^2.0.7"
             },
             "type": "wp-cli-package",
             "extra": {
@@ -1957,7 +1957,7 @@
             ],
             "description": "Executes arbitrary PHP code or files.",
             "homepage": "https://github.com/wp-cli/eval-command",
-            "time": "2018-08-05T09:25:28+00:00"
+            "time": "2018-09-21T10:39:36+00:00"
         },
         {
             "name": "wp-cli/export-command",
@@ -4599,16 +4599,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.3.1",
+            "version": "3.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "628a481780561150481a9ec74709092b9759b3ec"
+                "reference": "6ad28354c04b364c3c71a34e4a18b629cc3b231e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/628a481780561150481a9ec74709092b9759b3ec",
-                "reference": "628a481780561150481a9ec74709092b9759b3ec",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/6ad28354c04b364c3c71a34e4a18b629cc3b231e",
+                "reference": "6ad28354c04b364c3c71a34e4a18b629cc3b231e",
                 "shasum": ""
             },
             "require": {
@@ -4646,7 +4646,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-07-26T23:47:18+00:00"
+            "time": "2018-09-23T23:08:17+00:00"
         },
         {
             "name": "symfony/config",


### PR DESCRIPTION
```
Loading composer repositories with package information
The "https://packagist.org/packages.json" file could not be downloaded: failed to open stream: Connection timed out
https://packagist.org could not be fully loaded, package information was loaded from the local cache and may be out of date
Updating dependencies (including require-dev)
Package operations: 0 installs, 3 updates, 0 removals
  - Updating wp-cli/core-command (v2.0.0 => v2.0.1): Loading from cache
  - Updating wp-cli/eval-command (v2.0.0 => v2.0.1): Downloading (100%)
  - Updating squizlabs/php_codesniffer (3.3.1 => 3.3.2): Loading from cache
Writing lock file
Generating autoload files
PHP CodeSniffer Config installed_paths set to ../../phpcompatibility/phpcompatibility-wp/,../../phpcompatibility/php-compatibility/,../../wp-coding-standards/wpcs/
```