### PR TITLE
Update Composer dependencies (2018-10-05)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2977,12 +2977,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/wp-cli.git",
-                "reference": "174a897c61dd2b90649804886107d24b39eeca67"
+                "reference": "4edd90ca30cd3c6d000a35236eb62806cf0b4c0e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/174a897c61dd2b90649804886107d24b39eeca67",
-                "reference": "174a897c61dd2b90649804886107d24b39eeca67",
+                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/4edd90ca30cd3c6d000a35236eb62806cf0b4c0e",
+                "reference": "4edd90ca30cd3c6d000a35236eb62806cf0b4c0e",
                 "shasum": ""
             },
             "require": {
@@ -3027,20 +3027,20 @@
                 "cli",
                 "wordpress"
             ],
-            "time": "2018-10-02 11:06:45"
+            "time": "2018-10-03 15:43:46"
         },
         {
             "name": "wp-cli/wp-config-transformer",
-            "version": "v1.2.1",
+            "version": "v1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/wp-config-transformer.git",
-                "reference": "6ce0a9fae09d53145c9c9c79486a69684598488d"
+                "reference": "c469771d29279e5d7a8a2065f6be809ae66a47cc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/wp-config-transformer/zipball/6ce0a9fae09d53145c9c9c79486a69684598488d",
-                "reference": "6ce0a9fae09d53145c9c9c79486a69684598488d",
+                "url": "https://api.github.com/repos/wp-cli/wp-config-transformer/zipball/c469771d29279e5d7a8a2065f6be809ae66a47cc",
+                "reference": "c469771d29279e5d7a8a2065f6be809ae66a47cc",
                 "shasum": ""
             },
             "require": {
@@ -3068,7 +3068,7 @@
                 }
             ],
             "description": "Programmatically edit a wp-config.php file.",
-            "time": "2018-03-20T16:19:27+00:00"
+            "time": "2018-10-03T10:40:09+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
```
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 0 installs, 2 updates, 0 removals
  - Updating wp-cli/wp-config-transformer (v1.2.1 => v1.2.2): Loading from cache
  - Updating wp-cli/wp-cli dev-master (174a897 => 4edd90c):  Checking out 4edd90ca30
Writing lock file
Generating autoload files
PHP CodeSniffer Config installed_paths set to ../../phpcompatibility/php-compatibility/,../../wp-coding-standards/wpcs/,../../phpcompatibility/phpcompatibility-wp/
```