### PR TITLE
Update Composer dependencies (2018-11-12)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2977,12 +2977,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/wp-cli.git",
-                "reference": "2b71f95895a387dcdf5106c2c54b6bddf26e3c2e"
+                "reference": "fb25dc91f9456a75b518db51bdb676c9ab8b2418"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/2b71f95895a387dcdf5106c2c54b6bddf26e3c2e",
-                "reference": "2b71f95895a387dcdf5106c2c54b6bddf26e3c2e",
+                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/fb25dc91f9456a75b518db51bdb676c9ab8b2418",
+                "reference": "fb25dc91f9456a75b518db51bdb676c9ab8b2418",
                 "shasum": ""
             },
             "require": {
@@ -3027,20 +3027,20 @@
                 "cli",
                 "wordpress"
             ],
-            "time": "2018-11-05 06:45:08"
+            "time": "2018-11-12 04:43:47"
         },
         {
             "name": "wp-cli/wp-config-transformer",
-            "version": "v1.2.2",
+            "version": "v1.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/wp-config-transformer.git",
-                "reference": "c469771d29279e5d7a8a2065f6be809ae66a47cc"
+                "reference": "d1a82e15c290d2a3e2c4f23234bf514ff8d9845f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/wp-config-transformer/zipball/c469771d29279e5d7a8a2065f6be809ae66a47cc",
-                "reference": "c469771d29279e5d7a8a2065f6be809ae66a47cc",
+                "url": "https://api.github.com/repos/wp-cli/wp-config-transformer/zipball/d1a82e15c290d2a3e2c4f23234bf514ff8d9845f",
+                "reference": "d1a82e15c290d2a3e2c4f23234bf514ff8d9845f",
                 "shasum": ""
             },
             "require": {
@@ -3068,7 +3068,7 @@
                 }
             ],
             "description": "Programmatically edit a wp-config.php file.",
-            "time": "2018-10-03T10:40:09+00:00"
+            "time": "2018-11-09T21:25:11+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
```
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 0 installs, 2 updates, 0 removals
  - Updating wp-cli/wp-config-transformer (v1.2.2 => v1.2.3): Loading from cache
  - Updating wp-cli/wp-cli dev-master (2b71f95 => fb25dc9):  Checking out fb25dc91f9
Writing lock file
Generating autoload files
PHP CodeSniffer Config installed_paths set to ../../phpcompatibility/phpcompatibility-wp/,../../phpcompatibility/php-compatibility/,../../wp-coding-standards/wpcs/
```