### PR TITLE
Update Composer dependencies (2018-11-25)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -632,16 +632,16 @@
         },
         {
             "name": "psr/log",
-            "version": "1.0.2",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
+                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
-                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
+                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
                 "shasum": ""
             },
             "require": {
@@ -675,7 +675,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2016-10-10T12:19:37+00:00"
+            "time": "2018-11-20T15:27:04+00:00"
         },
         {
             "name": "ramsey/array_column",
@@ -1508,16 +1508,16 @@
         },
         {
             "name": "wp-cli/cron-command",
-            "version": "v2.0.0",
+            "version": "v2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/cron-command.git",
-                "reference": "69097794fedbde914687dfd1b43b222931a272f1"
+                "reference": "1eadbe6d729a24073d5ce00171f06b4b8c065a9b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/cron-command/zipball/69097794fedbde914687dfd1b43b222931a272f1",
-                "reference": "69097794fedbde914687dfd1b43b222931a272f1",
+                "url": "https://api.github.com/repos/wp-cli/cron-command/zipball/1eadbe6d729a24073d5ce00171f06b4b8c065a9b",
+                "reference": "1eadbe6d729a24073d5ce00171f06b4b8c065a9b",
                 "shasum": ""
             },
             "require": {
@@ -1525,7 +1525,7 @@
             },
             "require-dev": {
                 "wp-cli/entity-command": "^1.3 || ^2",
-                "wp-cli/wp-cli-tests": "^2"
+                "wp-cli/wp-cli-tests": "^2.0.11"
             },
             "type": "wp-cli-package",
             "extra": {
@@ -1566,7 +1566,7 @@
             ],
             "description": "Tests, runs, and deletes WP-Cron events; manages WP-Cron schedules.",
             "homepage": "https://github.com/wp-cli/cron-command",
-            "time": "2018-08-05T13:26:12+00:00"
+            "time": "2018-11-24T09:09:49+00:00"
         },
         {
             "name": "wp-cli/db-command",
@@ -4118,7 +4118,8 @@
                 "pagarme/pagarme-php": ">=0,<3",
                 "paragonie/random_compat": "<2",
                 "paypal/merchant-sdk-php": "<3.12",
-                "phpmailer/phpmailer": ">=5,<5.2.24",
+                "phpmailer/phpmailer": ">=5,<5.2.27|>=6,<6.0.6",
+                "phpoffice/phpspreadsheet": "<=1.5",
                 "phpunit/phpunit": ">=4.8.19,<4.8.28|>=5.0.10,<5.6.3",
                 "phpwhois/phpwhois": "<=4.2.5",
                 "phpxmlrpc/extras": "<0.6.1",
@@ -4170,7 +4171,7 @@
                 "symfony/yaml": ">=2,<2.0.22|>=2.1,<2.1.7",
                 "tecnickcom/tcpdf": "<6.2.22",
                 "thelia/backoffice-default-template": ">=2.1,<2.1.2",
-                "thelia/thelia": ">=2.1.0-beta1,<2.1.3|>=2.1,<2.1.2",
+                "thelia/thelia": ">=2.1,<2.1.2|>=2.1.0-beta1,<2.1.3",
                 "theonedemon/phpwhois": "<=4.2.5",
                 "titon/framework": ">=0,<9.9.99",
                 "truckersmp/phpwhois": "<=4.3.1",
@@ -4227,7 +4228,7 @@
                 }
             ],
             "description": "Prevents installation of composer packages with known security vulnerabilities: no API, simply require it",
-            "time": "2018-11-01T18:39:28+00:00"
+            "time": "2018-11-21T13:18:22+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -4948,16 +4949,16 @@
         },
         {
             "name": "wp-cli/wp-cli-tests",
-            "version": "v2.0.10",
+            "version": "v2.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/wp-cli-tests.git",
-                "reference": "32de18d70ea79d30f10f8e24e77d23fb05ac413b"
+                "reference": "4ec287ae7871158061768ce97bc568a2433060ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/wp-cli-tests/zipball/32de18d70ea79d30f10f8e24e77d23fb05ac413b",
-                "reference": "32de18d70ea79d30f10f8e24e77d23fb05ac413b",
+                "url": "https://api.github.com/repos/wp-cli/wp-cli-tests/zipball/4ec287ae7871158061768ce97bc568a2433060ac",
+                "reference": "4ec287ae7871158061768ce97bc568a2433060ac",
                 "shasum": ""
             },
             "require": {
@@ -5010,7 +5011,7 @@
                 "cli",
                 "wordpress"
             ],
-            "time": "2018-08-24T15:13:24+00:00"
+            "time": "2018-11-17T16:29:04+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",


### PR DESCRIPTION
- Updating `psr/log` (1.0.2 => 1.1.0)
- Updating `wp-cli/wp-cli-tests` (v2.0.10 => v2.0.11)
- Updating `wp-cli/cron-command` (v2.0.0 => v2.0.1)