### PR TITLE
Move PHP 5.4 tests from `WP_VERSION` `latest` to `5.1`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ jobs:
     - stage: test
       php: 5.4
       dist: precise
-      env: WP_VERSION=latest
+      env: WP_VERSION=5.1
     - stage: deploy
       env: DEPLOY_BRANCH=master
       script: ./ci/deploy.sh


### PR DESCRIPTION
Related wp-cli/wp-cli#5127