### PR TITLE
Enhancement: Add PHP 7.3 to Travis CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,9 @@ jobs:
         - composer phpcs
       env: BUILD=sniff
     - stage: test
+      php: 7.3
+      env: WP_VERSION=latest
+    - stage: test
       php: 7.2
       env: WP_VERSION=latest
     - stage: test


### PR DESCRIPTION
This PR

* [x] adds PHP 7.3 to the Travis CI build matrix

Related to https://github.com/wp-cli/wp-cli/issues/5160.