### PR TITLE
Permit use of `php7.2-mysql` and `php7.3-mysql` in Debian build

### DIFF
--- a/utils/wp-cli-updatedeb.sh
+++ b/utils/wp-cli-updatedeb.sh
@@ -31,7 +31,7 @@ Architecture: all
 Maintainer: Alain Schlesser <alain.schlesser@gmail.com>
 Section: php
 Priority: optional
-Depends: php5-cli (>= 5.4) | php-cli | php7-cli, php5-mysql | php5-mysqlnd | php7.0-mysql | php7.1-mysql, mysql-client | mariadb-client
+Depends: php5-cli (>= 5.4) | php-cli | php7-cli, php5-mysql | php5-mysqlnd | php7.0-mysql | php7.1-mysql | php7.2-mysql | php7.3-mysql, mysql-client | mariadb-client
 Homepage: http://wp-cli.org/
 Description: wp-cli is a set of command-line tools for managing
  WordPress installations. You can update plugins, set up multisite


### PR DESCRIPTION
Fixes https://github.com/wp-cli/wp-cli-bundle/issues/80
Related https://github.com/wp-cli/wp-cli/issues/5239

cc @szepeviktor please check package names