### PR TITLE
Skip deploy step outisde of master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,5 +78,6 @@ jobs:
       dist: precise
       env: WP_VERSION=5.1
     - stage: deploy
+      if: branch = master
       env: DEPLOY_BRANCH=master
       script: ./ci/deploy.sh


### PR DESCRIPTION
Travis allows conditions to be used so the step can be completely skipped.

See https://docs.travis-ci.com/user/conditional-builds-stages-jobs/#conditional-stages