### PR TITLE
Add preliminary PHP 7.4 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,9 @@ jobs:
         - composer phpcs
       env: BUILD=sniff
     - stage: test
+      php: 7.4snapshot
+      env: WP_VERSION=latest
+    - stage: test
       php: 7.3
       env: WP_VERSION=latest
     - stage: test
@@ -80,3 +83,7 @@ jobs:
     - stage: deploy
       env: DEPLOY_BRANCH=master
       script: ./ci/deploy.sh
+  allow_failures:
+    - stage: test
+      php: 7.4snapshot
+      env: WP_VERSION=latest


### PR DESCRIPTION
The PHP 7.4 tests currently still allow for failures while we're preparing for the final release.