### PR TITLE
Enforce PHP 7.4 compatibility in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ jobs:
         - composer phpcs
       env: BUILD=sniff
     - stage: test
-      php: 7.4snapshot
+      php: 7.4
       env: WP_VERSION=latest
     - stage: test
       php: 7.3
@@ -83,7 +83,3 @@ jobs:
     - stage: deploy
       env: DEPLOY_BRANCH=master
       script: ./ci/deploy.sh
-  allow_failures:
-    - stage: test
-      php: 7.4snapshot
-      env: WP_VERSION=latest


### PR DESCRIPTION
This PR changes the Travis CI configuration to use PHP 7.4 for all main tests nd switches the PHP 7.4 tests from allowing failures to failing the build on errors.

It will also include any fixes that might be required to get the tests to pass.