### PR TITLE
Conditionally include react folder in phar

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -68,7 +68,7 @@ jobs:
           files: "composer.json, phpcs.xml.dist"
 
       - name: Set up PHP environment
-        if: steps.check_composer_file.outputs.files_exists == 'true'
+        if: steps.check_files.outputs.files_exists == 'true'
         uses: shivammathur/setup-php@v2
         with:
           php-version: '7.4'

--- a/utils/make-phar.php
+++ b/utils/make-phar.php
@@ -181,7 +181,6 @@ $finder
 	->in( WP_CLI_VENDOR_DIR . '/mustache' )
 	->in( WP_CLI_VENDOR_DIR . '/rmccue/requests' )
 	->in( WP_CLI_VENDOR_DIR . '/composer' )
-	->in( WP_CLI_VENDOR_DIR . '/react' )
 	->in( WP_CLI_VENDOR_DIR . '/symfony/finder' )
 	->in( WP_CLI_VENDOR_DIR . '/symfony/polyfill-ctype' )
 	->in( WP_CLI_VENDOR_DIR . '/symfony/polyfill-mbstring' )

--- a/utils/make-phar.php
+++ b/utils/make-phar.php
@@ -195,6 +195,10 @@ $finder
 	->exclude( 'tests' )
 	->exclude( 'Test' )
 	->exclude( 'Tests' );
+if ( is_dir( WP_CLI_VENDOR_DIR . '/react' ) ) {
+	$finder
+		->in( WP_CLI_VENDOR_DIR . '/react' );
+}
 if ( 'cli' === BUILD ) {
 	$finder
 		->in( WP_CLI_VENDOR_DIR . '/wp-cli/mustangostang-spyc' )


### PR DESCRIPTION
This folder only exists when Composer v2 was included, not when Composer
v1 is still in use.