### PR TITLE
Handle files with the .php8 extension

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -143,11 +143,11 @@ jobs:
       - name: Prepare test database
         if: steps.check_files.outputs.files_exists == 'true'
         run: |
-          export MYQSL_HOST=127.0.0.1
+          export MYSQL_HOST=127.0.0.1
           export MYSQL_TCP_PORT=${{ job.services.mysql.ports['3306'] }}
           mysql -e 'CREATE DATABASE IF NOT EXISTS wp_cli_test;' -uroot -proot
-          mysql -e 'GRANT ALL PRIVILEGES ON wp_cli_test.* TO "wp_cli_test"@"127.0.0.1" IDENTIFIED BY "password1"' -uroot -proot
-          mysql -e 'GRANT ALL PRIVILEGES ON wp_cli_test_scaffold.* TO "wp_cli_test"@"127.0.0.1" IDENTIFIED BY "password1"' -uroot -proot
+          mysql -e 'GRANT ALL PRIVILEGES ON wp_cli_test.* TO wp_cli_test@127.0.0.1 IDENTIFIED BY "password1"' -uroot -proot
+          mysql -e 'GRANT ALL PRIVILEGES ON wp_cli_test_scaffold.* TO wp_cli_test@127.0.0.1 IDENTIFIED BY "password1"' -uroot -proot
 
       - name: Run Behat
         if: steps.check_files.outputs.files_exists == 'true'

--- a/utils/make-phar.php
+++ b/utils/make-phar.php
@@ -177,7 +177,7 @@ $finder = new Finder();
 $finder
 	->files()
 	->ignoreVCS( true )
-	->name( '*.php' )
+	->name( '/\.*.php8?/' )
 	->in( WP_CLI_ROOT . '/php' )
 	->in( WP_CLI_BUNDLE_ROOT . '/php' )
 	->in( WP_CLI_VENDOR_DIR . '/mustache' )


### PR DESCRIPTION
This is necessary in order for the phar to include:
symfony/polyfill-mbstring/Resources/mb_convert_variables.php8

<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review (https://make.wordpress.org/cli/handbook/code-review/).
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
