### PR TITLE
Keep `symfony/polyfill-php80` in Phar

### DIFF
--- a/utils/make-phar.php
+++ b/utils/make-phar.php
@@ -200,6 +200,10 @@ if ( is_dir( WP_CLI_VENDOR_DIR . '/react' ) ) {
 	$finder
 		->in( WP_CLI_VENDOR_DIR . '/react' );
 }
+if ( is_dir( WP_CLI_VENDOR_DIR . '/symfony/polyfill-php80' ) ) {
+	$finder
+		->in( WP_CLI_VENDOR_DIR . '/symfony/polyfill-php80' );
+}
 if ( 'cli' === BUILD ) {
 	$finder
 		->in( WP_CLI_VENDOR_DIR . '/wp-cli/mustangostang-spyc' )


### PR DESCRIPTION
The `symfony/polyfill-php80` package is needed for some of the dependencies. Although the autoloader entry is already being kept, the files themselves are currently being stripped.