### PR TITLE
Add DEB build workflow

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -248,7 +248,7 @@ jobs:
           repository: wp-cli/builds
 
   build-rpm: #-----------------------------------------------------------------------
-    name: Deployment
+    name: Build RPM package
     runs-on: ubuntu-latest
     if: ${{ contains(github.ref, 'release') }}
     needs: [deploy]
@@ -293,6 +293,59 @@ jobs:
           git config --local user.name "GitHub Action"
           git add rpm
           git commit -m "rpm build: $GITHUB_REPOSITORY@$GITHUB_SHA"
+
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.ACTIONS_BOT }}
+          branch: gh-pages
+          repository: wp-cli/builds
+
+  build-deb: #-----------------------------------------------------------------------
+    name: Build DEB package
+    runs-on: ubuntu-latest
+    if: ${{ contains(github.ref, 'release') }}
+    needs: [build-rpm]
+
+    steps:
+      - name: Check out builds repository
+        uses: actions/checkout@v2
+        with:
+          repository: wp-cli/builds
+          token: ${{ secrets.ACTIONS_BOT }}
+
+      - name: Download built Phar file
+        uses: actions/download-artifact@v2
+        with:
+          name: wp-cli-phar
+
+      - name: Install DEB build tooling
+        run: |
+          sudo apt-get update
+          sudo apt-get install fakeroot lintian -y
+
+      - name: Download DEB build configuration
+        run: |
+          wget -O wp-cli-updatedeb.sh https://raw.githubusercontent.com/wp-cli/wp-cli-bundle/master/utils/wp-cli-updatedeb.sh
+
+      - name: Build DEB package
+        run: |
+          bash wp-cli-updatedeb.sh
+
+      - name: Verify built DEB package contents
+        run: |
+          ls .
+
+      - name: Copy DEB package into builds folder
+        run: |
+          cp -n php-wpcli*all.deb deb
+
+      - name: Commit files
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add deb
+          git commit -m "deb build: $GITHUB_REPOSITORY@$GITHUB_SHA"
 
       - name: Push changes
         uses: ad-m/github-push-action@master

--- a/utils/wp-cli-updatedeb.sh
+++ b/utils/wp-cli-updatedeb.sh
@@ -31,7 +31,7 @@ Architecture: all
 Maintainer: Alain Schlesser <alain.schlesser@gmail.com>
 Section: php
 Priority: optional
-Depends: php5-cli (>= 5.6) | php-cli | php7-cli, php5-mysql | php5-mysqlnd | php7.0-mysql | php7.1-mysql | php7.2-mysql | php7.3-mysql, mysql-client | mariadb-client
+Depends: php5-cli (>= 5.6) | php-cli | php7-cli, php5-mysql | php5-mysqlnd | php7.0-mysql | php7.1-mysql | php7.2-mysql | php7.3-mysql | php7.4-mysql | php8.0-mysql, mysql-client | mariadb-client
 Homepage: http://wp-cli.org/
 Description: wp-cli is a set of command-line tools for managing
  WordPress installations. You can update plugins, set up multisite
@@ -41,6 +41,12 @@ EOF
 }
 
 set -e
+
+# Download the binary if needed
+if [ ! -f "wp-cli.phar" ]; then
+	wget -nv -O wp-cli.phar "$PHAR"
+	chmod +x wp-cli.phar
+fi
 
 # deb's dir
 if ! [ -d "$DIR" ]; then
@@ -71,9 +77,8 @@ fi
 # content dirs
 [ -d usr/bin ] || mkdir -p usr/bin
 
-# download current version
-wget -nv -O usr/bin/wp "$PHAR" || die 3 "Phar download failure"
-chmod +x usr/bin/wp || die 4 "chmod failure"
+# move phar
+mv ../wp-cli.phar usr/bin/wp
 
 # get version
 WPCLI_VER="$(usr/bin/wp cli version | cut -d " " -f 2)"

--- a/utils/wp-cli-updaterpm.sh
+++ b/utils/wp-cli-updaterpm.sh
@@ -30,7 +30,7 @@ if ! hash php rpm; then
 fi
 
 # Download the binary if needed
-if [ ! -f "$FILE" ]; then
+if [ ! -f "wp-cli.phar" ]; then
 	wget -nv -O wp-cli.phar "$PHAR_URL"
 	chmod +x wp-cli.phar
 fi


### PR DESCRIPTION
This PR adds a GHA workflow to replace https://github.com/wp-cli/deb-build.