### PR TITLE
Update `wp-cli/wp-cli` and `wp-cli/db-command` for Windows fixes

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2116,16 +2116,16 @@
         },
         {
             "name": "wp-cli/db-command",
-            "version": "v2.0.23",
+            "version": "v2.0.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/db-command.git",
-                "reference": "0d9e365147b8ff93ea36760db6495d38813e5c18"
+                "reference": "196f4d3d171b79e19650182c645f854643439c9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/db-command/zipball/0d9e365147b8ff93ea36760db6495d38813e5c18",
-                "reference": "0d9e365147b8ff93ea36760db6495d38813e5c18",
+                "url": "https://api.github.com/repos/wp-cli/db-command/zipball/196f4d3d171b79e19650182c645f854643439c9e",
+                "reference": "196f4d3d171b79e19650182c645f854643439c9e",
                 "shasum": ""
             },
             "require": {
@@ -2184,9 +2184,9 @@
             "homepage": "https://github.com/wp-cli/db-command",
             "support": {
                 "issues": "https://github.com/wp-cli/db-command/issues",
-                "source": "https://github.com/wp-cli/db-command/tree/v2.0.23"
+                "source": "https://github.com/wp-cli/db-command/tree/v2.0.24"
             },
-            "time": "2022-10-13T20:42:23+00:00"
+            "time": "2022-10-28T17:58:13+00:00"
         },
         {
             "name": "wp-cli/embed-command",
@@ -3688,12 +3688,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/wp-cli.git",
-                "reference": "581c954394ed253858c753a419a42b5aca4d1dc6"
+                "reference": "2c7bd19a6d1077925eab4727bb55b2bcf03a22a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/581c954394ed253858c753a419a42b5aca4d1dc6",
-                "reference": "581c954394ed253858c753a419a42b5aca4d1dc6",
+                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/2c7bd19a6d1077925eab4727bb55b2bcf03a22a4",
+                "reference": "2c7bd19a6d1077925eab4727bb55b2bcf03a22a4",
                 "shasum": ""
             },
             "require": {
@@ -3752,7 +3752,7 @@
                 "issues": "https://github.com/wp-cli/wp-cli/issues",
                 "source": "https://github.com/wp-cli/wp-cli"
             },
-            "time": "2022-10-19T11:55:19+00:00"
+            "time": "2022-10-28T18:01:57+00:00"
         },
         {
             "name": "wp-cli/wp-config-transformer",


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/5521#issuecomment-1295286262

```
Updating dependencies
Lock file operations: 0 installs, 2 updates, 0 removals
  - Upgrading wp-cli/db-command (v2.0.23 => v2.0.24)
  - Upgrading wp-cli/wp-cli (dev-master 581c954 => dev-master 2c7bd19)
Writing lock file
```
