### PR TITLE
Detect if running phar via CLI SAPI

### DIFF
--- a/php/boot-phar.php
+++ b/php/boot-phar.php
@@ -1,5 +1,14 @@
 <?php
 
+if ( 'cli' !== PHP_SAPI ) {
+	echo "Only PHP-CLI access.\n";
+	echo "You're currently using the " . PHP_SAPI . " PHP SAPI.\n";
+	echo "If you're trying to run this file with a web browser, don't.\n";
+	echo "When running in command line, ensure that `php -v` has the\n";
+	echo "word \"cli\" in the first line of output.\n";
+	die( -1 );
+}
+
 // Store the path to the Phar early on for `Utils\phar-safe-path()` function.
 define( 'WP_CLI_PHAR_PATH', getcwd() );
 

--- a/php/boot-phar.php
+++ b/php/boot-phar.php
@@ -1,11 +1,11 @@
 <?php
 
 if ( 'cli' !== PHP_SAPI ) {
-	echo "Only PHP-CLI access.\n";
-	echo "You're currently using the " . PHP_SAPI . " PHP SAPI.\n";
-	echo "If you're trying to run this file with a web browser, don't.\n";
-	echo "When running in command line, ensure that `php -v` has the\n";
-	echo "word \"cli\" in the first line of output.\n";
+	echo "WP-CLI only works correctly from the command line, using the 'cli' PHP SAPI.\n",
+		"You're currently executing the WP-CLI binary via the '" . PHP_SAPI . "' PHP SAPI.\n",
+		"In case you were trying to run this file with a web browser, know that this cannot technically work.\n",
+		"When running the WP-CLI binary on the command line, you can ensure you're using the right PHP SAPI",
+		"by checking that `php -v` has the word 'cli' in the first line of output.\n";
 	die( -1 );
 }
 


### PR DESCRIPTION
Signed-off-by: GDR! <gdr@gdr.name>

Closes https://github.com/wp-cli/wp-cli/issues/5703

The PHAR build did not detect if cgi or fcgi SAPI has been used, and instead crashed with a hard to debug message.