### PR TITLE
Run `trunk` deploy tests against PHP 7 instead of PHP 5.6

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -71,13 +71,13 @@ jobs:
         wp: ['latest']
         mysql: ['8.0']
         include:
-          - php: '5.6'
+          - php: '7.0'
             wp: 'trunk'
             mysql: '8.0'
-          - php: '5.6'
+          - php: '7.0'
             wp: 'trunk'
             mysql: '5.7'
-          - php: '5.6'
+          - php: '7.0'
             wp: 'trunk'
             mysql: '5.6'
           - php: '7.4'


### PR DESCRIPTION
To address test failures in https://github.com/wp-cli/wp-cli-bundle/actions/runs/5543175671

See https://github.com/wp-cli/wp-cli/issues/5810