### PR TITLE
Update `composer.lock` (2023-08-17)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3634,12 +3634,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/wp-cli.git",
-                "reference": "5c4eeaae23e80c91f2905d03d60c47877e5f039c"
+                "reference": "a33e0f813e496f2d575424504ec6a4c10d9f2d63"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/5c4eeaae23e80c91f2905d03d60c47877e5f039c",
-                "reference": "5c4eeaae23e80c91f2905d03d60c47877e5f039c",
+                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/a33e0f813e496f2d575424504ec6a4c10d9f2d63",
+                "reference": "a33e0f813e496f2d575424504ec6a4c10d9f2d63",
                 "shasum": ""
             },
             "require": {
@@ -3697,7 +3697,7 @@
                 "issues": "https://github.com/wp-cli/wp-cli/issues",
                 "source": "https://github.com/wp-cli/wp-cli"
             },
-            "time": "2023-08-02T23:32:04+00:00"
+            "time": "2023-08-14T22:11:44+00:00"
         },
         {
             "name": "wp-cli/wp-config-transformer",


### PR DESCRIPTION
```
Loading composer repositories with package information
Info from https://repo.packagist.org: #StandWithUkraine
Updating dependencies
Lock file operations: 0 installs, 1 update, 0 removals
  - Upgrading wp-cli/wp-cli (dev-main 5c4eeaa => dev-main a33e0f8)
Writing lock file
```
