### PR TITLE
No longer necessary to test WordPress latest with PHP 5.6

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -67,7 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
+        php: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
         wp: ['latest']
         mysql: ['8.0']
         include:


### PR DESCRIPTION
From https://github.com/wp-cli/wp-cli-bundle/pull/567#issuecomment-1684040206