### PR TITLE
Store the outer filesystem's filename in a constant for later use

### DIFF
--- a/features/command.feature
+++ b/features/command.feature
@@ -1679,7 +1679,10 @@ Feature: WP-CLI Commands
 
   Scenario: Templates should still be found when WP CLI phar is renamed
     Given a WP installation
-    And these installed and active plugins: akismet
+    And these installed and active plugins:
+      """
+      akismet
+      """
     And a new Phar with the same version
 
     When I run `wp plugin status akismet`

--- a/features/command.feature
+++ b/features/command.feature
@@ -1676,3 +1676,14 @@ Feature: WP-CLI Commands
       """
       core custom-subcommand
       """
+
+  Scenario: Templates should still be found when WP CLI phar is renamed
+    Given a WP installation
+    And these installed and active plugins: akismet
+    And a new Phar with the same version
+
+    When I run `wp plugin status akismet`
+    Then STDOUT should contain:
+      """
+      Plugin akismet details:
+      """

--- a/php/boot-phar.php
+++ b/php/boot-phar.php
@@ -11,6 +11,7 @@ if ( 'cli' !== PHP_SAPI ) {
 
 // Store the path to the Phar early on for `Utils\phar-safe-path()` function.
 define( 'WP_CLI_PHAR_PATH', getcwd() );
+define( 'WP_CLI_PHAR_HOST_FILENAME', basename( dirname( __DIR__ ) ) );
 
 if ( file_exists( 'phar://wp-cli.phar/php/wp-cli.php' ) ) {
 	define( 'WP_CLI_ROOT', 'phar://wp-cli.phar' );


### PR DESCRIPTION
This is related to (and required for) https://github.com/wp-cli/wp-cli/pull/5962

This will set an extra constant that stores the outer filesystem's filename. When that filename doesn't match with the phar's internal filename (wp-cli.phar), the phar can't find internal files that use `__DIR__` for a reference point to the file.