### PR TITLE
Stop testing WP latest on PHP < 7.2

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -67,7 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
+        php: ['7.2', '7.3', '7.4', '8.0']
         wp: ['latest']
         mysql: ['8.0']
         include:


### PR DESCRIPTION
This is due to the change of PHP version requirements in WP 6.6

Fixes the deployment
