### PR TITLE
Update versions of WP-CLI used in tests

### DIFF
--- a/features/cli.feature
+++ b/features/cli.feature
@@ -71,24 +71,24 @@ Feature: `wp cli` tasks
       """
 
   @github-api
-  Scenario: Patch update from 0.14.0 to 0.14.1
+  Scenario: Patch update from 2.8.0 to 2.8.1
     Given an empty directory
-    And a new Phar with version "0.14.0"
+    And a new Phar with version "2.8.0"
 
     When I run `{PHAR_PATH} --version`
     Then STDOUT should be:
       """
-      WP-CLI 0.14.0
+      WP-CLI 2.8.0
       """
 
     When I run `{PHAR_PATH} cli update --patch --yes`
     Then STDOUT should contain:
       """
-      md5 hash verified: 3f5fa2fda8457a9a5dc9875f17a3716d
+      md5 hash verified: a0cf91756fd46903c83c436ec1d462eb
       """
     And STDOUT should contain:
       """
-      Success: Updated WP-CLI to 0.14.1
+      Success: Updated WP-CLI to 2.8.1
       """
     And STDERR should be empty
     And the return code should be 0
@@ -96,13 +96,13 @@ Feature: `wp cli` tasks
     When I run `{PHAR_PATH} --version`
     Then STDOUT should be:
       """
-      WP-CLI 0.14.1
+      WP-CLI 2.8.1
       """
 
   @github-api
-  Scenario: Not a patch update from 0.14.0
+  Scenario: Not a patch update from 2.8.0
     Given an empty directory
-    And a new Phar with version "0.14.0"
+    And a new Phar with version "2.8.0"
 
     When I run `{PHAR_PATH} cli update --no-patch --yes`
     Then STDOUT should contain:
@@ -111,15 +111,14 @@ Feature: `wp cli` tasks
     """
     And STDOUT should not contain:
     """
-    0.14.1
+    2.8.1
     """
     And STDERR should be empty
     And the return code should be 0
 
-  @require-php-5.6
   Scenario: Install WP-CLI nightly
     Given an empty directory
-    And a new Phar with version "0.14.0"
+    And a new Phar with version "2.8.0"
 
     When I run `{PHAR_PATH} cli update --nightly --yes`
     Then STDOUT should contain:
@@ -137,7 +136,7 @@ Feature: `wp cli` tasks
   @github-api
   Scenario: Install WP-CLI stable
     Given an empty directory
-    And a new Phar with version "0.14.0"
+    And a new Phar with version "2.8.0"
     And a session file:
       """
       y
@@ -150,7 +149,7 @@ Feature: `wp cli` tasks
     When I run `{PHAR_PATH} cli update --stable < session`
     Then STDOUT should contain:
       """
-      You have version 0.14.0. Would you like to update to the latest stable release? [y/n]
+      You have version 2.8.0. Would you like to update to the latest stable release? [y/n]
       """
     And STDOUT should contain:
       """

--- a/features/package.feature
+++ b/features/package.feature
@@ -6,7 +6,7 @@ Feature: Install WP-CLI packages
 
   Scenario: Install a package requiring a WP-CLI version that doesn't match
     Given an empty directory
-    And a new Phar with version "0.23.0"
+    And a new Phar with version "2.8.0"
     And a path-command/command.php file:
       """
       <?php
@@ -25,7 +25,7 @@ Feature: Install WP-CLI packages
           "files": [ "command.php" ]
         },
         "require": {
-          "wp-cli/wp-cli": ">=0.24.0"
+          "wp-cli/wp-cli": ">=2.9.0"
         },
         "require-dev": {
           "behat/behat": "~2.5"
@@ -44,7 +44,7 @@ Feature: Install WP-CLI packages
       """
     And STDOUT should contain:
       """
-      wp-cli/wp-cli >=0.24.0 -> satisfiable by
+      wp-cli/wp-cli >=2.9.0 -> satisfiable by
       """
     And STDERR should contain:
       """
@@ -55,12 +55,12 @@ Feature: Install WP-CLI packages
     When I run `cat {PACKAGE_PATH}composer.json`
     Then STDOUT should contain:
       """
-      "version": "0.23.0",
+      "version": "2.8.0",
       """
 
   Scenario: Install a package requiring a WP-CLI version that does match
     Given an empty directory
-    And a new Phar with version "0.23.0"
+    And a new Phar with version "2.8.0"
     And a path-command/command.php file:
       """
       <?php
@@ -79,7 +79,7 @@ Feature: Install WP-CLI packages
           "files": [ "command.php" ]
         },
         "require": {
-          "wp-cli/wp-cli": ">=0.22.0"
+          "wp-cli/wp-cli": ">=2.7.0"
         },
         "require-dev": {
           "behat/behat": "~2.5"
@@ -98,12 +98,12 @@ Feature: Install WP-CLI packages
     When I run `cat {PACKAGE_PATH}composer.json`
     Then STDOUT should contain:
       """
-      "version": "0.23.0",
+      "version": "2.8.0",
       """
 
   Scenario: Install a package requiring a WP-CLI alpha version that does match
     Given an empty directory
-    And a new Phar with version "0.23.0-alpha-90ecad6"
+    And a new Phar with version "2.8.0-alpha-90ecad6"
     And a path-command/command.php file:
       """
       <?php
@@ -122,7 +122,7 @@ Feature: Install WP-CLI packages
           "files": [ "command.php" ]
         },
         "require": {
-          "wp-cli/wp-cli": ">=0.22.0"
+          "wp-cli/wp-cli": ">=2.7.0"
         },
         "require-dev": {
           "behat/behat": "~2.5"
@@ -141,5 +141,5 @@ Feature: Install WP-CLI packages
     When I run `cat {PACKAGE_PATH}composer.json`
     Then STDOUT should contain:
       """
-      "version": "0.23.0-alpha",
+      "version": "2.8.0-alpha",
       """


### PR DESCRIPTION
On newer PHP versions, some tests start to fail because the old WP-CLI phars are throwing type errors.

This PR changes to more recent versions of the WP-CLI phar that don't trigger those errors.