### PR TITLE
Fix workflow trigger to allow manual dispatch

### DIFF
--- a/.github/workflows/update-framework.yml
+++ b/.github/workflows/update-framework.yml
@@ -1,7 +1,7 @@
 name: Update wp-cli framework
 
 on:
-  workflow_call:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/update-framework.yml
+++ b/.github/workflows/update-framework.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Check out source code
         uses: actions/checkout@v4
 
-      - name: Set up PHP envirnoment
+      - name: Set up PHP environment
         uses: shivammathur/setup-php@v2
         with:
           php-version: '7.4'

--- a/.github/workflows/update-framework.yml
+++ b/.github/workflows/update-framework.yml
@@ -90,7 +90,7 @@ jobs:
         with:
           source_branch: update-framework
           destination_branch: ${{ github.event.repository.default_branch }}
-          github_token: ${{ secrets.REPO_GITHUB_TOKEN }}
+          github_token: ${{ secrets.ACTIONS_BOT }}
           pr_title: Update wp-cli framework
           pr_body: "**This is an automated pull-request**\n\nUpdates the `wp-cli/wp-cli` framework to the latest changeset."
           pr_label: scope:framework

--- a/composer.lock
+++ b/composer.lock
@@ -3662,12 +3662,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/wp-cli.git",
-                "reference": "a177d5aa6ca228b90eb553b710b96b8fabc14a81"
+                "reference": "e214df253932712ebe0669d50bb485276a9a5102"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/a177d5aa6ca228b90eb553b710b96b8fabc14a81",
-                "reference": "a177d5aa6ca228b90eb553b710b96b8fabc14a81",
+                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/e214df253932712ebe0669d50bb485276a9a5102",
+                "reference": "e214df253932712ebe0669d50bb485276a9a5102",
                 "shasum": ""
             },
             "require": {
@@ -3725,7 +3725,7 @@
                 "issues": "https://github.com/wp-cli/wp-cli/issues",
                 "source": "https://github.com/wp-cli/wp-cli"
             },
-            "time": "2024-10-01T12:21:39+00:00"
+            "time": "2024-10-01T17:32:53+00:00"
         },
         {
             "name": "wp-cli/wp-config-transformer",


### PR DESCRIPTION
To-do:

* Test manual dispatching
* Test with branch existing but no PR existing
* Consider removing [`repo-sync/pull-request`](https://github.com/repo-sync/pull-request) across the whole org as it is deprecated