### PR TITLE
Require `wp-cli/wp-cli` v2.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "wp-cli/shell-command": "^2",
     "wp-cli/super-admin-command": "^2",
     "wp-cli/widget-command": "^2",
-    "wp-cli/wp-cli": "dev-main"
+    "wp-cli/wp-cli": "^2.12"
   },
   "require-dev": {
     "roave/security-advisories": "dev-latest",


### PR DESCRIPTION
For improved PHP 8.4 compatibility.