### PR TITLE
Update `wp-cli/php-cli-tools`, fix failing tests

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3663,12 +3663,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/wp-cli.git",
-                "reference": "349cf0c4ff3135a063184b49a9a6f85654b50c45"
+                "reference": "0187f2b4ce7e83f31bf4beecd5ad4f11ddf8b57b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/349cf0c4ff3135a063184b49a9a6f85654b50c45",
-                "reference": "349cf0c4ff3135a063184b49a9a6f85654b50c45",
+                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/0187f2b4ce7e83f31bf4beecd5ad4f11ddf8b57b",
+                "reference": "0187f2b4ce7e83f31bf4beecd5ad4f11ddf8b57b",
                 "shasum": ""
             },
             "require": {
@@ -3726,7 +3726,7 @@
                 "issues": "https://github.com/wp-cli/wp-cli/issues",
                 "source": "https://github.com/wp-cli/wp-cli"
             },
-            "time": "2024-11-25T13:41:33+00:00"
+            "time": "2024-11-26T19:13:58+00:00"
         },
         {
             "name": "wp-cli/wp-config-transformer",
@@ -7208,16 +7208,16 @@
         },
         {
             "name": "wp-cli/wp-cli-tests",
-            "version": "v4.3.4",
+            "version": "v4.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/wp-cli-tests.git",
-                "reference": "a8de3f02e16d1133c3b9f3b865e4821250bb9f37"
+                "reference": "3c29e6ae528938781f775b56ab72cfe315b40d5f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/wp-cli-tests/zipball/a8de3f02e16d1133c3b9f3b865e4821250bb9f37",
-                "reference": "a8de3f02e16d1133c3b9f3b865e4821250bb9f37",
+                "url": "https://api.github.com/repos/wp-cli/wp-cli-tests/zipball/3c29e6ae528938781f775b56ab72cfe315b40d5f",
+                "reference": "3c29e6ae528938781f775b56ab72cfe315b40d5f",
                 "shasum": ""
             },
             "require": {
@@ -7283,7 +7283,7 @@
                 "issues": "https://github.com/wp-cli/wp-cli-tests/issues",
                 "source": "https://github.com/wp-cli/wp-cli-tests"
             },
-            "time": "2024-10-01T15:44:01+00:00"
+            "time": "2024-11-24T07:57:26+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",

--- a/composer.lock
+++ b/composer.lock
@@ -3100,20 +3100,20 @@
         },
         {
             "name": "wp-cli/php-cli-tools",
-            "version": "v0.11.22",
+            "version": "v0.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/php-cli-tools.git",
-                "reference": "a6bb94664ca36d0962f9c2ff25591c315a550c51"
+                "reference": "d1fe500378f53fb5ae1072c0daa77095c384a082"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/php-cli-tools/zipball/a6bb94664ca36d0962f9c2ff25591c315a550c51",
-                "reference": "a6bb94664ca36d0962f9c2ff25591c315a550c51",
+                "url": "https://api.github.com/repos/wp-cli/php-cli-tools/zipball/d1fe500378f53fb5ae1072c0daa77095c384a082",
+                "reference": "d1fe500378f53fb5ae1072c0daa77095c384a082",
                 "shasum": ""
             },
             "require": {
-                "php": ">= 5.3.0"
+                "php": ">= 5.6.0"
             },
             "require-dev": {
                 "roave/security-advisories": "dev-latest",
@@ -3157,9 +3157,9 @@
             ],
             "support": {
                 "issues": "https://github.com/wp-cli/php-cli-tools/issues",
-                "source": "https://github.com/wp-cli/php-cli-tools/tree/v0.11.22"
+                "source": "https://github.com/wp-cli/php-cli-tools/tree/v0.12.1"
             },
-            "time": "2023-12-03T19:25:05+00:00"
+            "time": "2024-10-01T11:13:49+00:00"
         },
         {
             "name": "wp-cli/rewrite-command",
@@ -3663,12 +3663,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/wp-cli.git",
-                "reference": "2b052f9f1cd5a1773b9cdf80120b42fe60a8dcca"
+                "reference": "349cf0c4ff3135a063184b49a9a6f85654b50c45"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/2b052f9f1cd5a1773b9cdf80120b42fe60a8dcca",
-                "reference": "2b052f9f1cd5a1773b9cdf80120b42fe60a8dcca",
+                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/349cf0c4ff3135a063184b49a9a6f85654b50c45",
+                "reference": "349cf0c4ff3135a063184b49a9a6f85654b50c45",
                 "shasum": ""
             },
             "require": {
@@ -3677,7 +3677,7 @@
                 "php": "^5.6 || ^7.0 || ^8.0",
                 "symfony/finder": ">2.7",
                 "wp-cli/mustangostang-spyc": "^0.6.3",
-                "wp-cli/php-cli-tools": "~0.11.2"
+                "wp-cli/php-cli-tools": "~0.12.1"
             },
             "require-dev": {
                 "roave/security-advisories": "dev-latest",
@@ -3726,7 +3726,7 @@
                 "issues": "https://github.com/wp-cli/wp-cli/issues",
                 "source": "https://github.com/wp-cli/wp-cli"
             },
-            "time": "2024-11-24T20:55:05+00:00"
+            "time": "2024-11-25T13:41:33+00:00"
         },
         {
             "name": "wp-cli/wp-config-transformer",

--- a/features/requests.feature
+++ b/features/requests.feature
@@ -211,7 +211,8 @@ Feature: Requests integration with both v1 and v2
       """
 
     # This can throw deprecated warnings on PHP 8.1+.
-    When I try `vendor/bin/wp plugin install duplicate-post --activate`
+    # Also, using a specific version to avoid minimum WordPress version requirement warning.
+    When I try `vendor/bin/wp plugin install duplicate-post --version=4.2 --activate`
     Then STDOUT should contain:
       """
       Success: Installed 1 of 1 plugins.


### PR DESCRIPTION
Achieved using `composer update -W wp-cli/wp-cli`

Addresses the following composer failure: https://github.com/wp-cli/wp-cli-bundle/actions/runs/12031139247/job/33540008660