### PR TITLE
Add manifest.json file for builds

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -54,6 +54,12 @@ jobs:
           name: cli_version
           path: cli_version.txt
 
+      - name: Upload manifest file
+        uses: actions/upload-artifact@v4
+        with:
+          name: manifest
+          path: vendor/wp-cli/wp-cli/manifest.json
+
       - name: Build the Phar file
         run: php -dphar.readonly=0 utils/make-phar.php wp-cli.phar --version=$CLI_VERSION
 
@@ -213,6 +219,11 @@ jobs:
         run: |
           cat cli_version.txt > phar/NIGHTLY_VERSION
 
+      - name: Download manifest file
+        uses: actions/download-artifact@v4
+        with:
+          name: manifest
+
       - name: Download built Phar file
         uses: actions/download-artifact@v4
         with:
@@ -222,11 +233,17 @@ jobs:
         if: ${{ contains(github.ref, 'release') }}
         run: |
           echo 'FILENAME=wp-cli-release.phar' > $GITHUB_ENV
+          echo 'MANIFEST_FILENAME=wp-cli-release.manifest.json' > $GITHUB_ENV
 
       - name: Set file name for main branch
         if: ${{ contains(github.ref, 'main') }}
         run: |
           echo 'FILENAME=wp-cli-nightly.phar' > $GITHUB_ENV
+          echo 'MANIFEST_FILENAME=wp-cli-nightly.manifest.json' > $GITHUB_ENV
+
+      - name: Move manifest file into correct location
+        run: |
+          mv manifest.json phar/$MANIFEST_FILENAME
 
       - name: Move built Phar file into correct location
         run: |


### PR DESCRIPTION
Relates to / depends on https://github.com/wp-cli/wp-cli/pull/6037

Adds the `manifest.json` file from the `wp-cli/wp-cli` root folder for every build.

For stable builds, the file is latter added to the actual GitHub release and fetched from there.

For nightly builds the file is fetched directly from `https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli-nightly.manifest.json`.

When calling `wp cli check-update`, it will fetch the manifest file for stable releases and nightly builds to check whether the PHP version requirement is met.