### PR TITLE
Deployment: Fix `FILENAME` env var

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -232,14 +232,14 @@ jobs:
       - name: Set file name for release branch
         if: ${{ contains(github.ref, 'release') }}
         run: |
-          echo 'FILENAME=wp-cli-release.phar' > $GITHUB_ENV
-          echo 'MANIFEST_FILENAME=wp-cli-release.manifest.json' > $GITHUB_ENV
+          echo 'FILENAME=wp-cli-release.phar' >> $GITHUB_ENV
+          echo 'MANIFEST_FILENAME=wp-cli-release.manifest.json' >> $GITHUB_ENV
 
       - name: Set file name for main branch
         if: ${{ contains(github.ref, 'main') }}
         run: |
-          echo 'FILENAME=wp-cli-nightly.phar' > $GITHUB_ENV
-          echo 'MANIFEST_FILENAME=wp-cli-nightly.manifest.json' > $GITHUB_ENV
+          echo 'FILENAME=wp-cli-nightly.phar' >> $GITHUB_ENV
+          echo 'MANIFEST_FILENAME=wp-cli-nightly.manifest.json' >> $GITHUB_ENV
 
       - name: Move manifest file into correct location
         run: |


### PR DESCRIPTION
One `>` overrides, but `>>` appends.

This caused an issue where `FILENAME` was not defined and so the nightly phar wasn't correctly replaced.

See broken commit: https://github.com/wp-cli/builds/commit/2c9f9b7066afe84eb9f3ebcba0be58fc75131db1
