### PR TITLE
Add missing manifest file to build commits

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -262,7 +262,7 @@ jobs:
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add phar/$FILENAME phar/$FILENAME.md5 phar/$FILENAME.sha512 phar/NIGHTLY_VERSION
+          git add phar/$FILENAME phar/$FILENAME.md5 phar/$FILENAME.sha512 phar/NIGHTLY_VERSION phar/$MANIFEST_FILENAME
           git commit -m "phar build: $GITHUB_REPOSITORY@$GITHUB_SHA"
 
       - name: Push changes


### PR DESCRIPTION
I don't know how I missed this, but this is a follow-up to #692 and #696 so that the manifest file is actually committed and added to https://github.com/wp-cli/builds/tree/gh-pages/phar