### PR TITLE
Fix broken phar tests

### DIFF
--- a/features/package.feature
+++ b/features/package.feature
@@ -6,7 +6,7 @@ Feature: Install WP-CLI packages
 
   Scenario: Install a package requiring a WP-CLI version that doesn't match
     Given an empty directory
-    And a new Phar with version "2.8.0"
+    And a new Phar with version "2.10.0"
     And a path-command/command.php file:
       """
       <?php
@@ -25,7 +25,7 @@ Feature: Install WP-CLI packages
           "files": [ "command.php" ]
         },
         "require": {
-          "wp-cli/wp-cli": ">=2.9.0"
+          "wp-cli/wp-cli": ">=2.11.0"
         },
         "require-dev": {
           "behat/behat": "~2.5"
@@ -44,7 +44,7 @@ Feature: Install WP-CLI packages
       """
     And STDOUT should contain:
       """
-      wp-cli/wp-cli >=2.9.0 -> satisfiable by
+      wp-cli/wp-cli >=2.11.0 -> satisfiable by
       """
     And STDERR should contain:
       """
@@ -55,12 +55,12 @@ Feature: Install WP-CLI packages
     When I run `cat {PACKAGE_PATH}composer.json`
     Then STDOUT should contain:
       """
-      "version": "2.8.0",
+      "version": "2.10.0",
       """
 
   Scenario: Install a package requiring a WP-CLI version that does match
     Given an empty directory
-    And a new Phar with version "2.8.0"
+    And a new Phar with version "2.11.0"
     And a path-command/command.php file:
       """
       <?php
@@ -79,7 +79,7 @@ Feature: Install WP-CLI packages
           "files": [ "command.php" ]
         },
         "require": {
-          "wp-cli/wp-cli": ">=2.7.0"
+          "wp-cli/wp-cli": ">=2.10.0"
         },
         "require-dev": {
           "behat/behat": "~2.5"
@@ -98,12 +98,12 @@ Feature: Install WP-CLI packages
     When I run `cat {PACKAGE_PATH}composer.json`
     Then STDOUT should contain:
       """
-      "version": "2.8.0",
+      "version": "2.11.0",
       """
 
   Scenario: Install a package requiring a WP-CLI alpha version that does match
     Given an empty directory
-    And a new Phar with version "2.8.0-alpha-90ecad6"
+    And a new Phar with version "2.12.0-alpha-90ecad6"
     And a path-command/command.php file:
       """
       <?php
@@ -122,7 +122,7 @@ Feature: Install WP-CLI packages
           "files": [ "command.php" ]
         },
         "require": {
-          "wp-cli/wp-cli": ">=2.7.0"
+          "wp-cli/wp-cli": ">=2.11.0"
         },
         "require-dev": {
           "behat/behat": "~2.5"
@@ -141,5 +141,5 @@ Feature: Install WP-CLI packages
     When I run `cat {PACKAGE_PATH}composer.json`
     Then STDOUT should contain:
       """
-      "version": "2.8.0-alpha",
+      "version": "2.12.0-alpha",
       """

--- a/utils/make-phar.php
+++ b/utils/make-phar.php
@@ -228,6 +228,7 @@ if ( 'cli' === BUILD ) {
 		->in( WP_CLI_VENDOR_DIR . '/nb/oxymel' )
 		->in( WP_CLI_VENDOR_DIR . '/psr' )
 		->in( WP_CLI_VENDOR_DIR . '/seld' )
+		->in( WP_CLI_VENDOR_DIR . '/marc-mabe/php-enum' ) // required by justinrainbow/json-schema.
 		->in( WP_CLI_VENDOR_DIR . '/justinrainbow/json-schema' )
 		->in( WP_CLI_VENDOR_DIR . '/gettext' )
 		->in( WP_CLI_VENDOR_DIR . '/mck89' )

--- a/utils/make-phar.php
+++ b/utils/make-phar.php
@@ -228,7 +228,6 @@ if ( 'cli' === BUILD ) {
 		->in( WP_CLI_VENDOR_DIR . '/nb/oxymel' )
 		->in( WP_CLI_VENDOR_DIR . '/psr' )
 		->in( WP_CLI_VENDOR_DIR . '/seld' )
-		->in( WP_CLI_VENDOR_DIR . '/marc-mabe/php-enum' ) // required by justinrainbow/json-schema.
 		->in( WP_CLI_VENDOR_DIR . '/justinrainbow/json-schema' )
 		->in( WP_CLI_VENDOR_DIR . '/gettext' )
 		->in( WP_CLI_VENDOR_DIR . '/mck89' )
@@ -244,6 +243,11 @@ if ( 'cli' === BUILD ) {
 		->exclude( 'composer/composer/src/Composer/Question' )
 		->exclude( 'composer/composer/src/Composer/Repository/Pear' )
 		->exclude( 'composer/composer/src/Composer/SelfUpdate' );
+
+	// required by justinrainbow/json-schema v6+.
+	if ( is_dir( WP_CLI_VENDOR_DIR . '/marc-mabe/php-enum' ) ) {
+		$finder->in( WP_CLI_VENDOR_DIR . '/marc-mabe/php-enum' );
+	}
 }
 
 foreach ( $finder as $file ) {


### PR DESCRIPTION
I noticed some failures in https://github.com/wp-cli/automated-tests/actions/runs/14743840901

They appear to happen because nowadays `justinrainbow/json-schema` depends on `marc-mabe/php-enum`, so this PR fixes that by adding this package to the phar file.

The tests here in this repo were not affected. Only the automated-tests repo.

---

Additionally, I took this as a opportunity to update the versions of WP-CLI used in tests to ensure they continue working fine on newer PHP versions. Previously: #658