### PR TITLE
Set custom`autoloader-suffix`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,7 @@
       "dealerdirect/phpcodesniffer-composer-installer": true,
       "johnpbloch/wordpress-core-installer": true
     },
+    "autoloader-suffix": "WpCliBundle",
     "platform": {
       "php": "5.6"
     },


### PR DESCRIPTION
This is related to the remaining failing Behat tests when code coverage is running.

Basically what happens in the wp-cli-bundle repo is that we include the autoloader once in `generate-coverage.php`, and then in the generated Phar the same autoloader is included again. That causes a fatal error because the same `ComposerAutoloaderInit...` class is declared twice.

This PR addresses this by hardcoding the autoloader class suffix so that it can be temporarily changed in the tests when generating a temp Phar. See https://github.com/wp-cli/wp-cli-tests/pull/256