### PR TITLE
Windows: Add hardening when renaming Phar during update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "wp-cli/site-health-command": "^1",
     "wp-cli/super-admin-command": "^2",
     "wp-cli/widget-command": "^2",
-    "wp-cli/wp-cli": "dev-main"
+    "wp-cli/wp-cli": "dev-fix/harden-update as 2.13.0"
   },
   "require-dev": {
     "roave/security-advisories": "dev-latest",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c2c06eaebfeb4c1884f044c795b98d19",
+    "content-hash": "93b1c074cda6e66d95df0980c27025c0",
     "packages": [
         {
             "name": "composer/semver",
@@ -2661,16 +2661,16 @@
         },
         {
             "name": "wp-cli/wp-cli",
-            "version": "dev-main",
+            "version": "dev-fix/harden-update",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/wp-cli.git",
-                "reference": "13ae7ab75f4baa2f593a4a029dc3979646495430"
+                "reference": "0fe2e0ec14f94aba9409d7d3d7a3e8a185c10742"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/13ae7ab75f4baa2f593a4a029dc3979646495430",
-                "reference": "13ae7ab75f4baa2f593a4a029dc3979646495430",
+                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/0fe2e0ec14f94aba9409d7d3d7a3e8a185c10742",
+                "reference": "0fe2e0ec14f94aba9409d7d3d7a3e8a185c10742",
                 "shasum": ""
             },
             "require": {
@@ -2693,7 +2693,6 @@
                 "ext-readline": "Include for a better --prompt implementation",
                 "ext-zip": "Needed to support extraction of ZIP archives when doing downloads or updates"
             },
-            "default-branch": true,
             "bin": [
                 "bin/wp",
                 "bin/wp.bat"
@@ -2741,7 +2740,7 @@
                 "issues": "https://github.com/wp-cli/wp-cli/issues",
                 "source": "https://github.com/wp-cli/wp-cli"
             },
-            "time": "2026-04-14T18:25:32+00:00"
+            "time": "2026-04-15T12:33:46+00:00"
         },
         {
             "name": "wp-cli/wp-config-transformer",
@@ -9787,7 +9786,14 @@
             "time": "2025-02-09T18:58:54+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "package": "wp-cli/wp-cli",
+            "version": "dev-fix/harden-update",
+            "alias": "2.13.0",
+            "alias_normalized": "2.13.0.0"
+        }
+    ],
     "minimum-stability": "dev",
     "stability-flags": {
         "roave/security-advisories": 20,


### PR DESCRIPTION
To test whether https://github.com/wp-cli/wp-cli/pull/6297 fixes the following test failure here:

001 Scenario: Install WP-CLI nightly                      # features\cli.feature:119
      When I run `{PHAR_PATH} cli update --nightly --yes` # features\cli.feature:123
        $ php C:\Users\runneradmin\AppData\Local\Temp\wp-cli-test-run--69dea741de85d2.37607601\wp-cli-build-69dea741deb690.93926654.phar cli update --nightly --yes
        Downloading from https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli-nightly.phar...
        sha512 hash verified: 208bab2070a699bf87474ce711867fb2b6607f1ab27ab1efbe480b8815a1c2fadd1b7b50fe2aeced5038d46190196297c92c86cbc727df1dec7efa5f215dc25e
        New version works. Proceeding to replace.
        
        PHP Warning:  rename(C:\Users\RUNNER~1\AppData\Local\Temp/wp_69dea77007ade6.45222671.phar,C:\Users\runneradmin\AppData\Local\Temp\wp-cli-test-run--69dea741de85d2.37607601\wp-cli-build-69dea741deb690.93926654.phar): Access is denied (code: 5) in phar://C:/Users/runneradmin/AppData/Local/Temp/wp-cli-test-run--69dea741de85d2.37607601/wp-cli-build-69dea741deb690.93926654.phar/vendor/wp-cli/wp-cli/php/commands/src/CLI_Command.php on line 512
        Warning: rename(C:\Users\RUNNER~1\AppData\Local\Temp/wp_69dea77007ade6.45222671.phar,C:\Users\runneradmin\AppData\Local\Temp\wp-cli-test-run--69dea741de85d2.37607601\wp-cli-build-69dea741deb690.93926654.phar): Access is denied (code: 5) in phar://C:/Users/runneradmin/AppData/Local/Temp/wp-cli-test-run--69dea741de85d2.37607601/wp-cli-build-69dea741deb690.93926654.phar/vendor/wp-cli/wp-cli/php/commands/src/CLI_Command.php on line 512
        Error: Cannot move C:\Users\RUNNER~1\AppData\Local\Temp/wp_69dea77007ade6.45222671.phar to C:\Users\runneradmin\AppData\Local\Temp\wp-cli-test-run--69dea741de85d2.37607601\wp-cli-build-69dea741deb690.93926654.phar
        cwd: C:\Users\runneradmin\AppData\Local\Temp\wp-cli-test-run--69dea741de85d2.37607601/
        run time: 0.80361080169678
        exit status: 1
        
        The command unexpectedly exited with status 1. If you expect a non-zero exit status, use `When I try [...]`. Else, this may be a bug in your code or test. (RuntimeException)