### PR TITLE
Fix update-framework workflow when there is an existing PR

### DIFF
--- a/.github/workflows/update-framework.yml
+++ b/.github/workflows/update-framework.yml
@@ -17,6 +17,7 @@ concurrency:
 
 permissions:
   contents: write
+  issues: read
   pull-requests: write
 
 jobs:
@@ -72,7 +73,7 @@ jobs:
 
             git push -f origin update-framework
 
-            PR_NUMBER=$(gh pr list --head update-framework --json number --jq '.[0].number // empty')
+            PR_NUMBER=$(gh pr list --head "update-framework" --state open --template '{{range .}}{{ .number }}{{end}}')
             if [ -z "$PR_NUMBER" ]; then
               gh pr create \
                 --title "Update wp-cli framework" \


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli-bundle/actions/runs/29848186175/job/88694048220 which caused me to look into this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated framework maintenance workflow permissions.
  * Improved detection of existing update pull requests during automated maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->