### PR TITLE
Fix update-framework workflow: Add `--json` arg

### DIFF
--- a/.github/workflows/update-framework.yml
+++ b/.github/workflows/update-framework.yml
@@ -73,7 +73,7 @@ jobs:
 
             git push -f origin update-framework
 
-            PR_NUMBER=$(gh pr list --head "update-framework" --state open --json number --template '{{range .}}{{ .number }}{{end}}')
+            PR_NUMBER=$(gh pr list --head "update-framework" --base "${{ github.event.repository.default_branch }}" --state open --json number --jq '.[0].number // empty')
             if [ -z "$PR_NUMBER" ]; then
               gh pr create \
                 --title "Update wp-cli framework" \

--- a/.github/workflows/update-framework.yml
+++ b/.github/workflows/update-framework.yml
@@ -59,6 +59,7 @@ jobs:
       - name: Commit and Create Pull Request
         env:
           GH_TOKEN: ${{ secrets.ACTIONS_BOT }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           PR_BODY: |
             **This is an automated pull-request**
 
@@ -73,19 +74,19 @@ jobs:
 
             git push -f origin update-framework
 
-            PR_NUMBER=$(gh pr list --head "update-framework" --base "${{ github.event.repository.default_branch }}" --state open --json number --jq '.[0].number // empty')
+            PR_NUMBER=$(gh api --method GET "repos/${{ github.repository }}/pulls" -f head="${{ github.repository_owner }}:update-framework" -f base="$DEFAULT_BRANCH" -f state="open" --jq '.[0].number // empty')
             if [ -z "$PR_NUMBER" ]; then
               gh pr create \
                 --title "Update wp-cli framework" \
                 --body "$PR_BODY" \
                 --label "scope:framework" \
-                --base "${{ github.event.repository.default_branch }}" \
+                --base "$DEFAULT_BRANCH" \
                 --head "update-framework"
             else
               gh pr edit "$PR_NUMBER" \
                 --title "Update wp-cli framework" \
                 --body "$PR_BODY" \
                 --add-label "scope:framework" \
-                --base "${{ github.event.repository.default_branch }}"
+                --base "$DEFAULT_BRANCH"
             fi
           fi

--- a/.github/workflows/update-framework.yml
+++ b/.github/workflows/update-framework.yml
@@ -73,7 +73,7 @@ jobs:
 
             git push -f origin update-framework
 
-            PR_NUMBER=$(gh pr list --head "update-framework" --state open --template '{{range .}}{{ .number }}{{end}}')
+            PR_NUMBER=$(gh pr list --head "update-framework" --state open --json number --template '{{range .}}{{ .number }}{{end}}')
             if [ -z "$PR_NUMBER" ]; then
               gh pr create \
                 --title "Update wp-cli framework" \


### PR DESCRIPTION
Follow-up to #1083

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the framework update workflow to automatically use the repository’s default branch as the PR base when creating or editing pull requests.
  * Improved detection of existing open pull requests for the framework update branch using an API-based lookup, reducing duplicate PRs and ensuring consistent updating and labeling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->