### PR TITLE
Update framework workflow: Use default token

### DIFF
--- a/.github/workflows/update-framework.yml
+++ b/.github/workflows/update-framework.yml
@@ -17,7 +17,6 @@ concurrency:
 
 permissions:
   contents: write
-  issues: read
   pull-requests: write
 
 jobs:
@@ -30,7 +29,7 @@ jobs:
       - name: Check out source code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          token: ${{ secrets.ACTIONS_BOT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up PHP environment
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
@@ -58,7 +57,7 @@ jobs:
 
       - name: Commit and Create Pull Request
         env:
-          GH_TOKEN: ${{ secrets.ACTIONS_BOT }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           PR_BODY: |
             **This is an automated pull-request**
@@ -74,7 +73,7 @@ jobs:
 
             git push -f origin update-framework
 
-            PR_NUMBER=$(gh api --method GET "repos/${{ github.repository }}/pulls" -f head="${{ github.repository_owner }}:update-framework" -f base="$DEFAULT_BRANCH" -f state="open" --jq '.[0].number // empty')
+            PR_NUMBER=$(gh pr list --head "update-framework" --base "$DEFAULT_BRANCH" --state open --json number --jq '.[0].number // empty')
             if [ -z "$PR_NUMBER" ]; then
               gh pr create \
                 --title "Update wp-cli framework" \


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review (https://make.wordpress.org/cli/handbook/code-review/).
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated framework update workflows to use standard authentication.
  * Improved pull request detection and streamlined workflow permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->