### PR TITLE
Add minimum PHP guard to Phar bootstrap

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,3 +13,31 @@ on:
 jobs:
   test:
     uses: wp-cli/.github/.github/workflows/reusable-testing.yml@main
+
+  minimum-php-guard:
+    name: Minimum PHP guard - PHP ${{ matrix.php }}
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['5.6', '7.1']
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up PHP environment
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
+        with:
+          php-version: '${{ matrix.php }}'
+          coverage: none
+
+      - name: Check minimum PHP guard
+        run: |
+          if php php/boot-phar.php > stdout.txt 2> stderr.txt; then
+            echo 'Expected boot-phar.php to reject unsupported PHP version.'
+            exit 1
+          fi
+
+          test ! -s stdout.txt
+          printf 'Error: WP-CLI requires PHP 7.2.24 or newer. You are running version %s.\n' "$(php -r 'echo PHP_VERSION;')" > expected.txt
+          diff -u expected.txt stderr.txt

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Check out source code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up PHP environment
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2

--- a/php/boot-phar.php
+++ b/php/boot-phar.php
@@ -1,11 +1,21 @@
 <?php
 
+// This file needs to parse without error in PHP 5.x.
+
 if ( 'cli' !== PHP_SAPI ) {
 	echo "WP-CLI only works correctly from the command line, using the 'cli' PHP SAPI.\n",
 		"You're currently executing the WP-CLI binary via the '" . PHP_SAPI . "' PHP SAPI.\n",
 		"In case you were trying to run this file with a web browser, know that this cannot technically work.\n",
 		"When running the WP-CLI binary on the command line, you can ensure you're using the right PHP SAPI",
 		"by checking that `php -v` has the word 'cli' in the first line of output.\n";
+	die( -1 );
+}
+
+if ( version_compare( PHP_VERSION, '7.2.24', '<' ) ) {
+	fwrite(
+		STDERR,
+		sprintf( "Error: WP-CLI requires PHP %s or newer. You are running version %s.\n", '7.2.24', PHP_VERSION )
+	);
 	die( -1 );
 }
 


### PR DESCRIPTION
## Context

The filesystem bootstrap (`php/boot-fs.php`) rejects PHP versions older than 7.2.24, but that file is not loaded by the Phar. The generated stub includes `php/boot-phar.php`, which loads `php/wp-cli.php` directly. `boot-fs.php` is only present in the archive because the framework package is bundled.

This initially looked like a release-critical safety gap for already shipped 2.x self-updaters. A deeper check showed that:

- The bundle requires PHP 7.2.24 and the current Phar contains Composer's generated `platform_check.php`, which enforces that requirement.
- The 2.x updater smoke-tests a downloaded Phar using `--info` and only replaces the existing Phar when that command succeeds.
- An end-to-end test with WP-CLI 2.12.0 on PHP 7.1 confirmed that the current nightly is rejected and the original Phar remains byte-for-byte unchanged.

The explicit guard is therefore defense-in-depth and a clearer diagnostic, rather than the only barrier preventing an unsupported update.

## Changes

- Reject unsupported PHP versions in `boot-phar.php` before loading the framework.
- Write the diagnostic to STDERR so existing 2.x self-updaters can relay it when validation fails.
- Test the guard on PHP 5.6 and PHP 7.1, ensuring that the bootstrap remains parseable, exits unsuccessfully, and produces the expected STDERR output.

## Testing

- `composer lint`
- `composer phpcs`
- `composer phpstan`
- `composer phpunit`
- `composer behat` (`53 scenarios`, `600 steps`)
- Focused guard checks on PHP 5.6.40 and PHP 7.1.33


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a runtime compatibility check that blocks execution on PHP versions older than 7.2.24.
  * Improved startup failure messaging to clearly state the minimum required PHP version and the detected version.
* **Tests**
  * Added a dedicated CI job to validate the rejection behavior for older supported PHP versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->