### PR TITLE
Add Behat scenarios for `wp cli update --stable` / `--nightly` PHP version checks

### DIFF
--- a/features/cli.feature
+++ b/features/cli.feature
@@ -173,3 +173,44 @@ Feature: `wp cli` tasks
       """
       WP-CLI {UPDATE_VERSION}
       """
+
+  Scenario: Prevent stable update when PHP version requirement is not met
+    Given an empty directory
+    And a new Phar with version "2.8.0"
+    And that HTTP requests to https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.manifest.json will respond with:
+      """
+      HTTP/1.1 200
+      Content-Type: application/json
+
+      {
+        "requires_php": "99.0.0"
+      }
+      """
+
+    When I try `{PHAR_PATH} cli update --stable --yes`
+    Then STDERR should contain:
+      """
+      The requested update requires PHP 99.0.0 or higher.
+      """
+    And the return code should be 1
+
+  Scenario: Prevent nightly update when PHP version requirement is not met
+    Given an empty directory
+    And a new Phar with version "2.8.0"
+    And that HTTP requests to https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli-nightly.manifest.json will respond with:
+      """
+      HTTP/1.1 200
+      Content-Type: application/json
+
+      {
+        "requires_php": "99.0.0"
+      }
+      """
+
+    When I try `{PHAR_PATH} cli update --nightly --yes`
+    Then STDERR should contain:
+      """
+      The requested update requires PHP 99.0.0 or higher.
+      """
+    And the return code should be 1
+


### PR DESCRIPTION
Accompanying test suite update for https://github.com/wp-cli/wp-cli/pull/6362, which gates `wp cli update --stable` and `wp cli update --nightly` on the minimum PHP version specified in the build channel manifest files (`wp-cli.manifest.json` and `wp-cli-nightly.manifest.json`).

These scenarios ensure that WP-CLI Phar self-updates abort early with a descriptive error message when a user's PHP version does not meet the manifest requirement, preventing broken Phar updates during PHP version floor bumps.

### Changes

Added two new Behat scenarios to `features/cli.feature`:
- **`Prevent stable update when PHP version requirement is not met`**: Stubs an HTTP response for `wp-cli.manifest.json` with `"requires_php": "99.0.0"` and verifies that `{PHAR_PATH} cli update --stable --yes` exits with status 1 and reports the requirement.
- **`Prevent nightly update when PHP version requirement is not met`**: Stubs an HTTP response for `wp-cli-nightly.manifest.json` with `"requires_php": "99.0.0"` and verifies that `{PHAR_PATH} cli update --nightly --yes` exits with status 1 and reports the requirement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CLI updates now stop safely when the selected stable or nightly release requires an unsupported PHP version.
  * Clear error messages are shown instead of proceeding with an incompatible update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->