### PR TITLE
Use `actions/checkout` for RPM/DEB build configuration in deployment workflow

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -272,6 +272,11 @@ jobs:
           repository: wp-cli/builds
           token: ${{ secrets.ACTIONS_BOT }}
 
+      - name: Check out bundle repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: bundle
+
       - name: Download built Phar file
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -282,10 +287,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install rpm rpmlint -y
 
-      - name: Download RPM build configuration
+      - name: Copy RPM build configuration
         run: |
-          wget -O wp-cli-rpm.spec https://raw.githubusercontent.com/wp-cli/wp-cli-bundle/main/utils/wp-cli-rpm.spec
-          wget -O wp-cli-updaterpm.sh https://raw.githubusercontent.com/wp-cli/wp-cli-bundle/main/utils/wp-cli-updaterpm.sh
+          cp bundle/utils/wp-cli-rpm.spec .
+          cp bundle/utils/wp-cli-updaterpm.sh .
 
       - name: Build RPM package
         run: |
@@ -353,6 +358,11 @@ jobs:
           repository: wp-cli/builds
           token: ${{ secrets.ACTIONS_BOT }}
 
+      - name: Check out bundle repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: bundle
+
       - name: Download built Phar file
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -363,9 +373,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install fakeroot lintian -y
 
-      - name: Download DEB build configuration
+      - name: Copy DEB build configuration
         run: |
-          wget -O wp-cli-updatedeb.sh https://raw.githubusercontent.com/wp-cli/wp-cli-bundle/main/utils/wp-cli-updatedeb.sh
+          cp bundle/utils/wp-cli-updatedeb.sh .
 
       - name: Build DEB package
         run: |

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -275,6 +275,8 @@ jobs:
       - name: Check out bundle repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          repository: ${{ github.repository }}
+          ref: ${{ github.sha }}
           path: bundle
 
       - name: Download built Phar file
@@ -361,6 +363,8 @@ jobs:
       - name: Check out bundle repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          repository: ${{ github.repository }}
+          ref: ${{ github.sha }}
           path: bundle
 
       - name: Download built Phar file

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -278,6 +278,7 @@ jobs:
           repository: ${{ github.repository }}
           ref: ${{ github.sha }}
           path: bundle
+          persist-credentials: false
 
       - name: Download built Phar file
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -366,6 +367,7 @@ jobs:
           repository: ${{ github.repository }}
           ref: ${{ github.sha }}
           path: bundle
+          persist-credentials: false
 
       - name: Download built Phar file
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated RPM and DEB packaging workflows to source packaging scripts from the bundled repository during builds.
  * Removed external script downloads from the packaging process.
  * Build and verification steps remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->