### PR TITLE
Point Composer users to package-command when `wp package` is missing

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,6 +14,34 @@ jobs:
   test:
     uses: wp-cli/.github/.github/workflows/reusable-testing.yml@main
 
+  package-command-guidance:
+    name: Guidance for `wp package` without dev dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up PHP environment
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
+        with:
+          php-version: 'latest'
+          coverage: none
+
+      - name: Install without dev dependencies
+        run: composer install --no-dev --no-interaction --prefer-dist
+
+      - name: Check that `wp package` points at package-command
+        run: |
+          if vendor/bin/wp package > stdout.txt 2> stderr.txt; then
+            echo 'Expected `wp package` to fail without wp-cli/package-command.'
+            exit 1
+          fi
+
+          cat stderr.txt
+          grep -qF 'composer require wp-cli/package-command' stderr.txt
+
   minimum-php-guard:
     name: Minimum PHP guard - PHP ${{ matrix.php }}
     runs-on: ubuntu-22.04

--- a/composer.json
+++ b/composer.json
@@ -64,6 +64,9 @@
   "extra": {
     "branch-alias": {
       "dev-main": "2.12.x-dev"
+    },
+    "command-hints": {
+      "package": "The 'package' command is bundled with the WP-CLI Phar, but is an optional dependency of Composer-based installations. Run `composer require wp-cli/package-command` to add it, or manage WP-CLI packages as regular Composer dependencies of your project instead."
     }
   },
   "autoload-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f03ac6fe341ad9e168f2681ba5f5f1eb",
+    "content-hash": "3b6e0c3cf150c6bf331db35ffb72814e",
     "packages": [
         {
             "name": "composer/semver",


### PR DESCRIPTION
## Problem

Since #846 moved `wp-cli/package-command` to `require-dev`, it still ships in the Phar but is absent from Composer-based installations of the bundle. Installing the bundle via Composer is an anti-pattern, but people do it — and today they hit a dead end:

```
Error: 'package' is not a registered wp command. See 'wp help' for available commands.
```

Nothing tells them the command exists, that their install method is why it is missing, or that `composer require wp-cli/package-command` brings it back. The `suggest` entry added in #846 only surfaces at install time, long before anyone types `wp package`.

## Changes

Declares the guidance as metadata, using the `extra.command-hints` mechanism proposed in wp-cli/wp-cli#6386:

```json
"extra": {
  "command-hints": {
    "package": "The 'package' command is bundled with the WP-CLI Phar, but is an optional dependency of Composer-based installations. Run `composer require wp-cli/package-command` to add it, or manage WP-CLI packages as regular Composer dependencies of your project instead."
  }
}
```

Metadata rather than code because this package has no `autoload` section — `composer.json` is the only channel it has.

`composer.lock`'s `content-hash` is updated in the same commit, since `extra` feeds into it and the lock would otherwise be reported as stale.

## Result

Composer users get:

```
Error: 'package' is not a registered wp command. See 'wp help' for available commands.
The 'package' command is bundled with the WP-CLI Phar, but is an optional dependency
of Composer-based installations. Run `composer require wp-cli/package-command` to add
it, or manage WP-CLI packages as regular Composer dependencies of your project instead.
```

Phar users see no change — the hint only fires when the command is genuinely unregistered, and in the Phar `wp package` is registered. The single `package` entry also covers every subcommand, since `wp package install foo` fails on the top-level `package` lookup.

## Testing

A `package-command-guidance` job in `testing.yml` installs the bundle with `--no-dev` — the state Composer-based users end up in — and asserts `wp package` fails with the hint rather than a bare "not a registered wp command". Metadata that nothing reads is easy to break silently, so this guards against the entry being dropped or misnested, and against the framework renaming the `extra` key.

Two honest caveats:

- **The job exercises the root-package read path, not the installed.json path.** With `--no-dev` in this repo, the bundle *is* the root package, and the framework reads hints from the root `composer.json` as well as from `vendor/composer/installed.json`. Real users hit the latter, since for them the bundle is a dependency. Covering that path properly needs the bundle installed as a dependency of a scratch project, and wp-cli-tests currently offers no step for that — `Given a dependency on current wp-cli` hardcodes `wp-cli/wp-cli`, and `{SRC_DIR}` points at wp-cli-tests itself rather than the repo under test. An end-to-end Behat scenario here would need a wp-cli-tests change first. The installed.json path is worth covering directly in wp-cli/wp-cli#6386 instead.
- **This job will be red until wp-cli/wp-cli#6386 lands**, since the framework has no `CommandHints` on `dev-main` yet. That is the dependency showing up honestly in CI rather than being asserted only in prose.

Neither the job nor the hint text has been executed locally — the authoring environment could not complete a dependency install for this repo. The hint text itself was verified end to end against a simulated Composer project built from this `composer.json`, producing the output above, and `composer validate` passes with the regenerated lock hash.

## Dependency

Requires wp-cli/wp-cli#6386 for the metadata to be read. Until that lands the metadata is inert but harmless — an unrecognized `extra` key that Composer ignores.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added guidance for Composer-based installations when using the `wp package` command.
  - Users are directed to install the optional package command dependency when needed.

- **Tests**
  - Added automated verification that `wp package` displays the expected guidance when the optional dependency is not installed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->