### PR TITLE
Fix PHPCS errors in Behat test files

### DIFF
--- a/features/bootstrap.feature
+++ b/features/bootstrap.feature
@@ -8,11 +8,11 @@ Feature: Bootstrap WP-CLI
       """
       <?php
       if ( ! class_exists( 'WP_CLI' ) ) {
-        return;
+          return;
       }
-      $autoload = dirname( __FILE__ ) . '/vendor/autoload.php';
+      $autoload = __DIR__ . '/vendor/autoload.php';
       if ( file_exists( $autoload ) ) {
-        require_once $autoload;
+          require_once $autoload;
       }
       WP_CLI::add_command( 'cli', 'CLI_Command', array( 'when' => 'before_wp_load' ) );
       """
@@ -20,9 +20,9 @@ Feature: Bootstrap WP-CLI
       """
       <?php
       class CLI_Command extends WP_CLI_Command {
-        public function version() {
-          WP_CLI::success( "WP-Override-CLI" );
-        }
+          public function version() {
+              WP_CLI::success( 'WP-Override-CLI' );
+          }
       }
       """
     And a cli-override-command/composer.json file:

--- a/features/command.feature
+++ b/features/command.feature
@@ -822,9 +822,9 @@ Feature: WP-CLI Commands
             list( $name ) = $args;
             $type = $assoc_args['type'];
             WP_CLI::$type( "Hello, $name!" );
-          if ( isset( $assoc_args['honk'] ) ) {
-              WP_CLI::log( 'Honk!' );
-          }
+            if ( isset( $assoc_args['honk'] ) ) {
+                WP_CLI::log( 'Honk!' );
+            }
         };
           WP_CLI::add_command(
               'example hello',

--- a/features/command.feature
+++ b/features/command.feature
@@ -282,9 +282,8 @@ Feature: WP-CLI Commands
       class Custom_Command_Class extends WP_CLI_Command {
 
           public function valid() {
-             WP_CLI::success( 'Hello world' );
+              WP_CLI::success( 'Hello world' );
           }
-
       }
       WP_CLI::add_command( 'command', 'Custom_Command_Class' );
       """
@@ -308,8 +307,8 @@ Feature: WP-CLI Commands
        *
        * @when before_wp_load
        */
-      $foo = function( $args ) {
-        WP_CLI::success( $args[0] );
+      $foo = function ( $args ) {
+          WP_CLI::success( $args[0] );
       };
       WP_CLI::add_command( 'foo', $foo );
       """
@@ -352,7 +351,7 @@ Feature: WP-CLI Commands
        * @when before_wp_load
        */
       function foo( $args ) {
-        WP_CLI::success( $args[0] );
+          WP_CLI::success( $args[0] );
       }
       WP_CLI::add_command( 'foo', 'foo' );
       """
@@ -387,22 +386,22 @@ Feature: WP-CLI Commands
       """
       <?php
       class Foo_Class extends WP_CLI_Command {
-        protected $prefix;
+          protected $prefix;
 
-        public function __construct( $prefix ) {
-          $this->prefix = $prefix;
-        }
-        /**
-         * My awesome class method command
-         *
-         * <message>
-         * : An awesome message to display
-         *
-         * @when before_wp_load
-         */
-        function foo( $args ) {
-          WP_CLI::success( $this->prefix . ':' . $args[0] );
-        }
+          public function __construct( $prefix ) {
+              $this->prefix = $prefix;
+          }
+          /**
+           * My awesome class method command
+           *
+           * <message>
+           * : An awesome message to display
+           *
+           * @when before_wp_load
+           */
+          function foo( $args ) {
+              WP_CLI::success( $this->prefix . ':' . $args[0] );
+          }
       }
       $foo = new Foo_Class( 'boo' );
       WP_CLI::add_command( 'foo', array( $foo, 'foo' ) );
@@ -438,17 +437,17 @@ Feature: WP-CLI Commands
       """
       <?php
       class Foo_Class extends WP_CLI_Command {
-        /**
-         * My awesome class method command
-         *
-         * <message>
-         * : An awesome message to display
-         *
-         * @when before_wp_load
-         */
-        function foo( $args ) {
-          WP_CLI::success( $args[0] );
-        }
+          /**
+           * My awesome class method command
+           *
+           * <message>
+           * : An awesome message to display
+           *
+           * @when before_wp_load
+           */
+          function foo( $args ) {
+              WP_CLI::success( $args[0] );
+          }
       }
       WP_CLI::add_command( 'foo', array( 'Foo_Class', 'foo' ) );
       """
@@ -483,20 +482,20 @@ Feature: WP-CLI Commands
       """
       <?php
       class Foo_Class {
-        protected $message;
+          protected $message;
 
-        public function __construct( $message ) {
-          $this->message = $message;
-        }
+          public function __construct( $message ) {
+              $this->message = $message;
+          }
 
-        /**
-         * My awesome class method command
-         *
-         * @when before_wp_load
-         */
-        function __invoke( $args ) {
-          WP_CLI::success( $this->message );
-        }
+          /**
+           * My awesome class method command
+           *
+           * @when before_wp_load
+           */
+          function __invoke( $args ) {
+              WP_CLI::success( $this->message );
+          }
       }
       $foo = new Foo_Class( 'bar' );
       WP_CLI::add_command( 'instantiated-command', $foo );
@@ -515,19 +514,19 @@ Feature: WP-CLI Commands
       """
       <?php
       class Foo_Class extends WP_CLI_Command {
-        /**
-         * My awesome class method command
-         *
-         * <message>
-         * : An awesome message to display
-         *
-         * @when before_wp_load
-         */
-        function foo( $args ) {
-          WP_CLI::success( $args[0] );
-        }
+          /**
+           * My awesome class method command
+           *
+           * <message>
+           * : An awesome message to display
+           *
+           * @when before_wp_load
+           */
+          function foo( $args ) {
+              WP_CLI::success( $args[0] );
+          }
       }
-      $foo = new Foo_Class;
+      $foo = new Foo_Class();
       WP_CLI::add_command( 'bar', array( $foo, 'bar' ) );
       """
 
@@ -543,37 +542,41 @@ Feature: WP-CLI Commands
       """
       <?php
       function foo( $args, $assoc_args ) {
-        $message = array_shift( $args );
-        WP_CLI::log( 'Message is: ' . $message );
-        WP_CLI::success( $assoc_args['meal'] );
+          $message = array_shift( $args );
+          WP_CLI::log( 'Message is: ' . $message );
+          WP_CLI::success( $assoc_args['meal'] );
       }
-      WP_CLI::add_command( 'foo', 'foo', array(
-        'shortdesc'   => 'My awesome function command',
-        'when'        => 'before_wp_load',
-        'synopsis'    => array(
+      WP_CLI::add_command(
+          'foo',
+          'foo',
           array(
-            'type'          => 'positional',
-            'name'          => 'message',
-            'description'   => 'An awesome message to display',
-            'optional'      => false,
-            'options'       => array( 'hello', 'goodbye' ),
-          ),
-          array(
-            'type'          => 'assoc',
-            'name'          => 'apple',
-            'description'   => 'A type of fruit.',
-            'optional'      => false,
-          ),
-          array(
-            'type'          => 'assoc',
-            'name'          => 'meal',
-            'description'   => 'A type of meal.',
-            'optional'      => true,
-            'default'       => 'breakfast',
-            'options'       => array( 'breakfast', 'lunch', 'dinner' ),
-          ),
-        ),
-      ) );
+              'shortdesc'   => 'My awesome function command',
+              'when'        => 'before_wp_load',
+              'synopsis'    => array(
+                  array(
+                      'type'          => 'positional',
+                      'name'          => 'message',
+                      'description'   => 'An awesome message to display',
+                      'optional'      => false,
+                      'options'       => array( 'hello', 'goodbye' ),
+                  ),
+                  array(
+                      'type'          => 'assoc',
+                      'name'          => 'apple',
+                      'description'   => 'A type of fruit.',
+                      'optional'      => false,
+                  ),
+                  array(
+                      'type'          => 'assoc',
+                      'name'          => 'meal',
+                      'description'   => 'A type of meal.',
+                      'optional'      => true,
+                      'default'       => 'breakfast',
+                      'options'       => array( 'breakfast', 'lunch', 'dinner' ),
+                  ),
+              ),
+          )
+      );
       """
     And a wp-cli.yml file:
       """
@@ -660,18 +663,22 @@ Feature: WP-CLI Commands
     And a test-cmd.php file:
       """
       <?php
-      WP_CLI::add_command( 'foo', function( $args ){
-        WP_CLI::log( count( $args ) );
-      }, array(
-        'when' => 'before_wp_load',
-        'synopsis' => array(
+      WP_CLI::add_command(
+          'foo',
+          function ( $args ) {
+              WP_CLI::log( count( $args ) );
+          },
           array(
-            'type'      => 'positional',
-            'name'      => 'arg',
-            'repeating' => true,
-          ),
-        ),
-      ));
+              'when' => 'before_wp_load',
+              'synopsis' => array(
+                  array(
+                      'type'      => 'positional',
+                      'name'      => 'arg',
+                      'repeating' => true,
+                  ),
+              ),
+          )
+      );
       """
     And a wp-cli.yml file:
       """
@@ -696,18 +703,22 @@ Feature: WP-CLI Commands
     And a test-cmd.php file:
       """
       <?php
-      WP_CLI::add_command( 'foo', function( $_, $assoc_args ){
-        WP_CLI::log( \WP_CLI\Utils\get_flag_value( $assoc_args, 'honk' ) ? 'honked' : 'nohonk' );
-      }, array(
-        'when' => 'before_wp_load',
-        'synopsis' => array(
+      WP_CLI::add_command(
+          'foo',
+          function ( $_, $assoc_args ) {
+              WP_CLI::log( \WP_CLI\Utils\get_flag_value( $assoc_args, 'honk' ) ? 'honked' : 'nohonk' );
+          },
           array(
-            'type'     => 'flag',
-            'name'     => 'honk',
-            'optional' => true,
-          ),
-        ),
-      ));
+              'when' => 'before_wp_load',
+              'synopsis' => array(
+                  array(
+                      'type'     => 'flag',
+                      'name'     => 'honk',
+                      'optional' => true,
+                  ),
+              ),
+          )
+      );
       """
     And a wp-cli.yml file:
       """
@@ -760,13 +771,17 @@ Feature: WP-CLI Commands
       """
       <?php
       function foo() {
-        WP_CLI::success( 'Command run.' );
+          WP_CLI::success( 'Command run.' );
       }
-      WP_CLI::add_command( 'foo', 'foo', array(
-        'shortdesc'   => 'My awesome function command',
-        'when'        => 'before_wp_load',
-        'longdesc'    => '## EXAMPLES ' . PHP_EOL . PHP_EOL . '  # Run the custom foo command',
-      ) );
+      WP_CLI::add_command(
+          'foo',
+          'foo',
+          array(
+              'shortdesc'   => 'My awesome function command',
+              'when'        => 'before_wp_load',
+              'longdesc'    => '## EXAMPLES ' . PHP_EOL . PHP_EOL . '  # Run the custom foo command',
+          )
+      );
       """
     And a wp-cli.yml file:
       """
@@ -803,40 +818,44 @@ Feature: WP-CLI Commands
     Given a hello-command.php file:
       """
       <?php
-        $hello_command = function( $args, $assoc_args ) {
+        $hello_command = function ( $args, $assoc_args ) {
             list( $name ) = $args;
             $type = $assoc_args['type'];
             WP_CLI::$type( "Hello, $name!" );
-            if ( isset( $assoc_args['honk'] ) ) {
-                WP_CLI::log( 'Honk!' );
-            }
+          if ( isset( $assoc_args['honk'] ) ) {
+              WP_CLI::log( 'Honk!' );
+          }
         };
-        WP_CLI::add_command( 'example hello', $hello_command, array(
-            'shortdesc' => 'Prints a greeting.',
-            'synopsis' => array(
-                array(
-                    'type'      => 'positional',
-                    'name'      => 'name',
-                    'description' => 'Name of person to greet.',
-                    'optional'  => false,
-                    'repeating' => false,
-                ),
-                array(
-                    'type'     => 'assoc',
-                    'name'     => 'type',
-                    'optional' => true,
-                    'default'  => 'success',
-                    'options'  => array( 'success', 'error' ),
-                ),
-                array(
-                    'type'     => 'flag',
-                    'name'     => 'honk',
-                    'optional' => true,
-                ),
-            ),
-            'when' => 'after_wp_load',
-            'longdesc'    => "\r\n## EXAMPLES\n\n# Say hello to Newman\nwp example hello Newman\nSuccess: Hello, Newman!",
-      ) );
+          WP_CLI::add_command(
+              'example hello',
+              $hello_command,
+              array(
+                  'shortdesc' => 'Prints a greeting.',
+                  'synopsis' => array(
+                      array(
+                          'type'      => 'positional',
+                          'name'      => 'name',
+                          'description' => 'Name of person to greet.',
+                          'optional'  => false,
+                          'repeating' => false,
+                      ),
+                      array(
+                          'type'     => 'assoc',
+                          'name'     => 'type',
+                          'optional' => true,
+                          'default'  => 'success',
+                          'options'  => array( 'success', 'error' ),
+                      ),
+                      array(
+                          'type'     => 'flag',
+                          'name'     => 'honk',
+                          'optional' => true,
+                      ),
+                  ),
+                  'when' => 'after_wp_load',
+                  'longdesc'    => "\r\n## EXAMPLES\n\n# Say hello to Newman\nwp example hello Newman\nSuccess: Hello, Newman!",
+              )
+          );
       """
 
     When I run `wp --require=hello-command.php help example hello`
@@ -911,13 +930,13 @@ Feature: WP-CLI Commands
        *
        * @when before_wp_load
        */
-      $foo = function( $args, $assoc_args ) {
-        $out = array(
-          'bar'     => isset( $args[0] ) ? $args[0] : '',
-          'shop'    => isset( $args[1] ) ? $args[1] : '',
-          'burrito' => isset( $assoc_args['burrito'] ) ? $assoc_args['burrito'] : '',
-        );
-        WP_CLI::print_value( $out, array( 'format' => 'yaml' ) );
+      $foo = function ( $args, $assoc_args ) {
+          $out = array(
+              'bar'     => isset( $args[0] ) ? $args[0] : '',
+              'shop'    => isset( $args[1] ) ? $args[1] : '',
+              'burrito' => isset( $assoc_args['burrito'] ) ? $assoc_args['burrito'] : '',
+          );
+          WP_CLI::print_value( $out, array( 'format' => 'yaml' ) );
       };
       WP_CLI::add_command( 'foo', $foo );
       """
@@ -1022,11 +1041,11 @@ Feature: WP-CLI Commands
        *
        * @when before_wp_load
        */
-      $foo = function( $args, $assoc_args ) {
-        $out = array(
-          'burrito' => isset( $args[0] ) ? $args[0] : '',
-        );
-        WP_CLI::print_value( $out, array( 'format' => 'yaml' ) );
+      $foo = function ( $args, $assoc_args ) {
+          $out = array(
+              'burrito' => isset( $args[0] ) ? $args[0] : '',
+          );
+          WP_CLI::print_value( $out, array( 'format' => 'yaml' ) );
       };
       WP_CLI::add_command( 'foo', $foo );
       """
@@ -1056,10 +1075,13 @@ Feature: WP-CLI Commands
     And a remove-comment.php file:
       """
       <?php
-      WP_CLI::add_hook( 'after_add_command:comment', function () {
-        $command = WP_CLI::get_root_command();
-        $command->remove_subcommand( 'comment' );
-      } );
+      WP_CLI::add_hook(
+          'after_add_command:comment',
+          function () {
+              $command = WP_CLI::get_root_command();
+              $command->remove_subcommand( 'comment' );
+          }
+      );
       """
 
     When I run `wp`
@@ -1082,14 +1104,17 @@ Feature: WP-CLI Commands
       /**
        * @when before_wp_load
        */
-      $before_invoke = function() {
-        WP_CLI::success( 'Invoked' );
+      $before_invoke = function () {
+          WP_CLI::success( 'Invoked' );
       };
-      $before_invoke_args = array( 'before_invoke' => function() {
-        WP_CLI::success( 'before invoke' );
-      }, 'after_invoke' => function() {
-        WP_CLI::success( 'after invoke' );
-      });
+      $before_invoke_args = array(
+          'before_invoke' => function () {
+              WP_CLI::success( 'before invoke' );
+          },
+          'after_invoke' => function () {
+              WP_CLI::success( 'after invoke' );
+          },
+      );
       WP_CLI::add_command( 'before invoke', $before_invoke, $before_invoke_args );
       WP_CLI::add_command( 'before-invoke', $before_invoke, $before_invoke_args );
       """
@@ -1127,20 +1152,20 @@ Feature: WP-CLI Commands
       """
       <?php
       class Foo_Class {
-        protected $message;
+          protected $message;
 
-        public function __construct( $message ) {
-          $this->message = $message;
-        }
+          public function __construct( $message ) {
+              $this->message = $message;
+          }
 
-        /**
-         * My awesome class method command
-         *
-         * @when before_wp_load
-         */
-        function message( $args ) {
-          WP_CLI::success( $this->message );
-        }
+          /**
+           * My awesome class method command
+           *
+           * @when before_wp_load
+           */
+          function message( $args ) {
+              WP_CLI::success( $this->message );
+          }
       }
       $foo = new Foo_Class( 'bar' );
       WP_CLI::add_command( 'instantiated-command', $foo );
@@ -1198,9 +1223,12 @@ Feature: WP-CLI Commands
     And a abort-add-command.php file:
       """
       <?php
-      WP_CLI::add_hook( 'before_add_command:test-command-2', function ( $addition ) {
-        $addition->abort( 'Testing hooks.' );
-      } );
+      WP_CLI::add_hook(
+          'before_add_command:test-command-2',
+          function ( $addition ) {
+              $addition->abort( 'Testing hooks.' );
+          }
+      );
 
       WP_CLI::add_command( 'test-command-1', function () {} );
       WP_CLI::add_command( 'test-command-2', function () {} );
@@ -1233,9 +1261,12 @@ Feature: WP-CLI Commands
       class TestCommand {
       }
 
-      WP_CLI::add_hook( 'after_add_command:test-command', function () {
-        WP_CLI::add_command( 'test-command sub-command', function () {} );
-      } );
+      WP_CLI::add_hook(
+          'after_add_command:test-command',
+          function () {
+              WP_CLI::add_command( 'test-command sub-command', function () {} );
+          }
+      );
 
       WP_CLI::add_command( 'test-command', 'TestCommand' );
       """
@@ -1288,12 +1319,17 @@ Feature: WP-CLI Commands
       }
 
       function test_function() {
-        \WP_CLI::success( 'unknown-parent child-command' );
+          \WP_CLI::success( 'unknown-parent child-command' );
       }
 
       WP_CLI::add_command( 'unknown-parent child-command', 'test_function' );
 
-      WP_CLI::add_command( 'test-command sub-command', function () { \WP_CLI::success( 'test-command sub-command' ); } );
+      WP_CLI::add_command(
+          'test-command sub-command',
+          function () {
+              \WP_CLI::success( 'test-command sub-command' );
+          }
+      );
 
       WP_CLI::add_command( 'test-command', 'TestCommand' );
       """
@@ -1338,12 +1374,17 @@ Feature: WP-CLI Commands
       }
 
       function test_function() {
-        \WP_CLI::success( 'unknown-parent child-command' );
+          \WP_CLI::success( 'unknown-parent child-command' );
       }
 
       WP_CLI::add_command( 'unknown-parent child-command', 'test_function' );
 
-      WP_CLI::add_command( 'test-command sub-command', function () { \WP_CLI::success( 'test-command sub-command' ); } );
+      WP_CLI::add_command(
+          'test-command sub-command',
+          function () {
+              \WP_CLI::success( 'test-command sub-command' );
+          }
+      );
 
       WP_CLI::add_command( 'test-command', 'TestCommand' );
       """
@@ -1387,16 +1428,24 @@ Feature: WP-CLI Commands
       }
 
       function test_function() {
-        \WP_CLI::success( 'unknown-parent child-command' );
+          \WP_CLI::success( 'unknown-parent child-command' );
       }
 
-      WP_CLI::add_hook( 'after_wp_load', function(){
-        WP_CLI::add_command( 'unknown-parent child-command', 'test_function' );
+      WP_CLI::add_hook(
+          'after_wp_load',
+          function () {
+              WP_CLI::add_command( 'unknown-parent child-command', 'test_function' );
 
-        WP_CLI::add_command( 'test-command sub-command', function () { \WP_CLI::success( 'test-command sub-command' ); } );
+              WP_CLI::add_command(
+                  'test-command sub-command',
+                  function () {
+                      \WP_CLI::success( 'test-command sub-command' );
+                  }
+              );
 
-        WP_CLI::add_command( 'test-command', 'TestCommand' );
-      });
+              WP_CLI::add_command( 'test-command', 'TestCommand' );
+          }
+      );
       """
 
     # TODO: Throwing deprecations with PHP 8.1+ and WP < 5.9
@@ -1440,10 +1489,10 @@ Feature: WP-CLI Commands
            * @when after_wp_load
            */
           public function after_wp_load() {
-             var_dump( function_exists( 'home_url' ) );
+              var_dump( function_exists( 'home_url' ) );
           }
           public function before_wp_load() {
-             var_dump( function_exists( 'home_url' ) );
+              var_dump( function_exists( 'home_url' ) );
           }
       }
       WP_CLI::add_command( 'command', 'Custom_Command_Class' );
@@ -1488,11 +1537,11 @@ Feature: WP-CLI Commands
            * @when before_wp_load
            */
           public function before_wp_load() {
-             var_dump( function_exists( 'home_url' ) );
+              var_dump( function_exists( 'home_url' ) );
           }
 
           public function after_wp_load() {
-             var_dump( function_exists( 'home_url' ) );
+              var_dump( function_exists( 'home_url' ) );
           }
       }
       WP_CLI::add_command( 'command', 'Custom_Command_Class' );
@@ -1532,7 +1581,7 @@ Feature: WP-CLI Commands
            * @when after_wp_load
            */
           public function __invoke() {
-             var_dump( function_exists( 'home_url' ) );
+              var_dump( function_exists( 'home_url' ) );
           }
       }
       WP_CLI::add_command( 'command', 'Custom_Command_Class' );
@@ -1662,9 +1711,12 @@ Feature: WP-CLI Commands
     And a test-cmd.php file:
       """
       <?php
-      WP_CLI::add_wp_hook( 'plugins_loaded', function(){
-        WP_CLI::add_command( 'core custom-subcommand', function() {});
-      });
+      WP_CLI::add_wp_hook(
+          'plugins_loaded',
+          function () {
+              WP_CLI::add_command( 'core custom-subcommand', function () {} );
+          }
+      );
       """
     And a wp-cli.yml file:
       """

--- a/features/config.feature
+++ b/features/config.feature
@@ -19,9 +19,10 @@ Feature: wp-config.php tests
       // Provide defines that make use of __FILE__ and __DIR__.
       define( 'WP_CONTENT_DIR', __FILE__ . '/my-content/' );
       define( 'WP_PLUGIN_DIR', __DIR__ . '/my-plugins/' );
-      if ( ! defined( 'ABSPATH' ) )
-        define( 'ABSPATH', dirname( __FILE__ ) . '/' );
-      require_once( ABSPATH . 'wp-settings.php' );
+      if ( ! defined( 'ABSPATH' ) ) {
+          define( 'ABSPATH', __DIR__ . '/' );
+      }
+      require_once ABSPATH . 'wp-settings.php';
       """
 
     When I run `{PHAR_PATH} eval "echo 'WP_CONTENT_DIR => ' . WP_CONTENT_DIR;"`

--- a/features/package.feature
+++ b/features/package.feature
@@ -10,9 +10,13 @@ Feature: Install WP-CLI packages
     And a path-command/command.php file:
       """
       <?php
-      WP_CLI::add_command( 'community-command', function(){
-        WP_CLI::success( "success!" );
-      }, array( 'when' => 'before_wp_load' ) );
+      WP_CLI::add_command(
+          'community-command',
+          function () {
+              WP_CLI::success( 'success!' );
+          },
+          array( 'when' => 'before_wp_load' )
+      );
       """
     And a path-command/composer.json file:
       """
@@ -64,9 +68,13 @@ Feature: Install WP-CLI packages
     And a path-command/command.php file:
       """
       <?php
-      WP_CLI::add_command( 'community-command', function(){
-        WP_CLI::success( "success!" );
-      }, array( 'when' => 'before_wp_load' ) );
+      WP_CLI::add_command(
+          'community-command',
+          function () {
+              WP_CLI::success( 'success!' );
+          },
+          array( 'when' => 'before_wp_load' )
+      );
       """
     And a path-command/composer.json file:
       """
@@ -107,9 +115,13 @@ Feature: Install WP-CLI packages
     And a path-command/command.php file:
       """
       <?php
-      WP_CLI::add_command( 'community-command', function(){
-        WP_CLI::success( "success!" );
-      }, array( 'when' => 'before_wp_load' ) );
+      WP_CLI::add_command(
+          'community-command',
+          function () {
+              WP_CLI::success( 'success!' );
+          },
+          array( 'when' => 'before_wp_load' )
+      );
       """
     And a path-command/composer.json file:
       """

--- a/features/requests.feature
+++ b/features/requests.feature
@@ -39,7 +39,7 @@ Feature: Requests integration with both v1 and v2
     Given a check-request-v1-phar.php file:
       """
       <?php
-      var_dump( \WP_CLI\Utils\http_request( "GET", "https://example.com/" ) );
+      var_dump( \WP_CLI\Utils\http_request( 'GET', 'https://example.com/' ) );
       """
     When I run `vendor/bin/wp eval-file check-request-v1-phar.php`
     Then STDOUT should contain:
@@ -68,7 +68,7 @@ Feature: Requests integration with both v1 and v2
     Given a check-request-v1.php file:
       """
       <?php
-      var_dump( \WP_CLI\Utils\http_request( "GET", "https://example.com/" ) );
+      var_dump( \WP_CLI\Utils\http_request( 'GET', 'https://example.com/' ) );
       """
     When I run `wp eval-file check-request-v1.php`
     Then STDOUT should contain:
@@ -107,7 +107,7 @@ Feature: Requests integration with both v1 and v2
     Given a check-request-v2.php file:
       """
       <?php
-      var_dump( \WP_CLI\Utils\http_request( "GET", "https://example.com/" ) );
+      var_dump( \WP_CLI\Utils\http_request( 'GET', 'https://example.com/' ) );
       """
     When I run `wp eval-file check-request-v2.php`
     Then STDOUT should contain:
@@ -175,7 +175,7 @@ Feature: Requests integration with both v1 and v2
       """
     And an extra-config.php file:
       """
-      require __DIR__ . "/../vendor/autoload.php";
+      require __DIR__ . '/../vendor/autoload.php';
       """
     And the {RUN_DIR}/vendor/wp-cli/wp-cli/bundle/rmccue/requests directory should exist
     And the {RUN_DIR}/vendor/rmccue/requests directory should not exist


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated end-to-end test fixtures to use consistent PHP coding standards.
  - Standardized string quoting, indentation, multi-line command registrations, and directory path handling.
  - Preserved all existing scenarios, assertions, expected outputs, and test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->